### PR TITLE
Mention Redis requirement in the README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-[Python 3.6](https://www.python.org/downloads/release/python-360/)
+[Python 3.6](https://www.python.org/downloads/release/python-360/), [Redis](https://redis.io/)
 
 [redis](https://redis.io/)
 
@@ -34,6 +34,8 @@ Form submissions are powered by [directory-forms-api](https://github.com/uktrade
     $ make debug
 
 ### Run debug webserver
+
+> Make sure to have Redis running before attemptying to serve pages, e.g. with the `redis-server` command.
 
     $ make debug_webserver
 


### PR DESCRIPTION
Trying to run this project the first time around, I got the following error when loading a page:

```
redis.exceptions.ConnectionError: Error 61 connecting to localhost:6379. Connection refused.
```

I just `brew install`ed redis and started it with `redis-server`, and thought this should be mentioned in the README. Someone who understands more about the setup might want to add further info (required Redis version?) / move the bits I added elsewhere.