### PR TITLE
Update recommended host & port in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Signed cookies are used as the session backend to avoid using a database. We the
 To be able to test cookies locally add the following to your `/etc/hosts`:
 
 ```
-127.0.0.1       int.trade.great
+127.0.0.1       international.trade.great
 ```
 
-Then run the server and visit `int.trade.great:8013`
+Then run the server and visit `international.trade.great:8012`
 
 
 [circle-ci-image]: https://circleci.com/gh/uktrade/great-international-ui/tree/master.svg?style=svg


### PR DESCRIPTION
Again something minor I stumbled upon – `directory-cms` refers to another host than the one that was in the README (https://github.com/uktrade/directory-cms/blob/898d264d44bf284a6e1ea0c79f64700ffe798f02/makefile#L66), and the `PORT` is set to 8012 in the makefile.

This is the only spot I could find where `int.trade.great` is used so I think updating it here is enough.