### PR TITLE
Copy dummy_page before mutation

### DIFF
--- a/core/tests/test_templates.py
+++ b/core/tests/test_templates.py
@@ -17,7 +17,7 @@ dummy_page = {
 
 def test_homepage_button_how_to_do_business_feature_off():
 
-    page = dummy_page
+    page = dummy_page.copy()
     page['hero_cta_text'] = 'Hero CTA text'
 
     context = {
@@ -35,7 +35,7 @@ def test_homepage_button_how_to_do_business_feature_off():
 
 def test_homepage_button_how_to_do_business_feature_on():
 
-    page = dummy_page
+    page = dummy_page.copy()
     page['hero_cta_text'] = 'Hero CTA text'
 
     context = {

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -708,7 +708,7 @@ def test_how_to_do_business_feature_off(mock_get_page, client, settings):
 def test_how_to_do_business_feature_on(mock_get_page, client, settings):
     settings.FEATURE_FLAGS['HOW_TO_DO_BUSINESS_ON'] = True
 
-    page = dummy_page
+    page = dummy_page.copy()
     page['page_type'] = 'InternationalCuratedTopicLandingPage'
 
     mock_get_page.return_value = create_response(


### PR DESCRIPTION
``page = dummy_page`` doesn't copy the underlying data so any subsequent mutation will also mutate the original ``dummy_page`` and leak into later tests.