### PR TITLE
CI-108: Turn off custom tags for GA temporarily.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Implemented enhancements:
 
 - CMS-1480 - Add translations to po files and templates
+- CI-108 - Temporarily turn off additional GA tagging.
 
 ### Fixed bugs
 

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -22,17 +22,6 @@
   <script src="{% static 'directory_components/js/dit.components.greatInternationalHeader.js' %}"></script>
 {% endblock %}
 
-{% block head_js_ga360 %}
-    {{ block.super }}
-    {% if ga360 %}
-        <script src="{% static 'js/dit.tagging.js' %}"></script>
-        <script id="ga360-script">
-            window.dataLayer.push({ 'pageCategory': '{{ ga360.page_type }}' });
-            dit.tagging.international.init('{{ ga360.page_type }}');
-        </script>
-    {% endif %}
-{% endblock %}
-
 {% block head_other %}{% endblock %}
 
 {% block head_sharing_metadata %}


### PR DESCRIPTION
The spec for the data to be sent in these tags has been changed.
We don't have time to update and test the changes before release, so we are temporarily turning off this feature in preference to sending incorrect and potentially confusing data.

General GA data (eg tracking of the URLs that that user visits) will not be affected by this commit and will continue to send as normal.