### PR TITLE
Fix image being squashed on guide landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - No ticket - Updated `directory_components` to `20.3.1` and `directory_constants` to `18.1.2`
 - CI-313 - Update JS dev dependencies to cover security vulnerabilities
 - No ticket - Updated directory components requirements to fix pagination bug
+- CI-352 - Fix image being squashed on guide landing page
 
 ### Implemented enhancements
 - CI-267 - Added cta text and link for sector page for related opportunities section

--- a/core/templates/core/uk_setup_guide/guide_landing_page.html
+++ b/core/templates/core/uk_setup_guide/guide_landing_page.html
@@ -47,15 +47,16 @@
   <section class="background-great-blue">
     <div class="container">
       <div class="cta-block flex-grid padding-vertical-90">
-        <div class="column-two-thirds">
-          <img class="cta-block-image" src="{{ page.section_two_image.url }}" alt="" width="100%" height="auto">
+        <div class="column-two-thirds center-vertical flex-shrink-0 max-width-100">
+            {% if page.section_two_image.url %}
+                <figure class="landing-page-image flex-shrink-0">
+                    <img class="width-full" src="{{page.section_two_image.url}}" alt="">
+                </figure>
+            {% endif %}
         </div>
-
-        <div class="column-third white-text cta-block-content">
-          <h3 class="heading-large">{{ page.section_two_heading }}</h3>
-
-          <p class="padding-bottom-30">{{ page.section_two_teaser }}</p>
-
+        <div class="column-third white-text cta-block-content padding-left-60-xl">
+            <h3 class="heading-large">{{ page.section_two_heading }}</h3>
+            <p class="padding-bottom-30">{{ page.section_two_teaser }}</p>
             <a href="{{ page.section_two_button_url }}" class="button button-blue">{{ page.section_two_button_text }}</a>
         </div>
       </div>

--- a/core/templates/core/uk_setup_guide/guide_landing_page.html
+++ b/core/templates/core/uk_setup_guide/guide_landing_page.html
@@ -57,7 +57,7 @@
         <div class="column-third white-text cta-block-content padding-left-60-xl">
             <h3 class="heading-large">{{ page.section_two_heading }}</h3>
             <p class="padding-bottom-30">{{ page.section_two_teaser }}</p>
-            <a href="{{ page.section_two_button_url }}" class="button button-blue">{{ page.section_two_button_text }}</a>
+            <a href="{{ page.section_two_button_url }}" class="button button-blue margin-bottom-45">{{ page.section_two_button_text }}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if adding HTML) Change is accessible to the standards we subscribe to.
 - [x] (if changing the UI) Add a printscreen to the PR

![image](https://user-images.githubusercontent.com/43139274/61702797-535eb400-ad38-11e9-9078-de92495b97ab.png)
