### PR TITLE
no ticket: Fix hero images for topic and guide listing pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - CI-368 - Add ebooks promotional section on "why choose the UK" page
 - No ticket - Fixed Industries landing page extending tag being in the wrong order
 - No ticket - Fix hero image on international home page
+- No ticket - Fix hero images on topic and guide landing pages.
 
 ### Implemented enhancements
 - CI-267 - Added cta text and link for sector page for related opportunities section

--- a/core/templates/core/topic_list.html
+++ b/core/templates/core/topic_list.html
@@ -1,20 +1,14 @@
 {% extends 'core/base_cms.html' %}
 
 {% load filter_by_active_language from cms_tags %}
-{% load breadcrumbs card from directory_components %}
+{% load breadcrumbs card hero from directory_components %}
 
 {% block css_layout_class %}article-list-page{% endblock css_layout_class %}
 
 {% block content %}
 
 {% block hero %}
-  <section class="hero hero-generic padding-0" {% if page.hero_image %}style="background-image: url('{{ page.hero_image.url }}')"{% endif %}>
-    <div class="container">
-      <div class="hero-title-compact">
-        <h1 class="heading-hero-generic{% if page.breadcrumbs_label|length > 15 %}-compact{% endif %}" id="hero-heading">{{ page.landing_page_title }}</h1>
-      </div>
-    </div>
-  </section>
+  {% hero background_image_url=page.hero_image.url hero_text=page.landing_page_title large_title=True %}
 {% endblock %}
 
 <section class="breadcrumbs-section">

--- a/core/templates/core/uk_setup_guide/guide_landing_page.html
+++ b/core/templates/core/uk_setup_guide/guide_landing_page.html
@@ -7,14 +7,7 @@
 {% block css_layout_class %}curated-topic-landing-page{% endblock css_layout_class %}
 
 {% block content %}
-
-  <section class="hero hero-generic padding-0" id="campaign-hero" style="background-image: url('{{ page.hero_image.url }}')">
-    <div class="container white-text">
-      <div class="hero-title">
-        <h1 class="heading-hero-generic">{{ page.display_title }}</h1>
-      </div>
-    </div>
-  </section>
+  {% hero background_image_url=page.hero_image.url hero_text=page.display_title large_title=True %}
 
   <div class="container">
 


### PR DESCRIPTION
Another quick hotfix for the hero images, this time on the topic and guide landing pages.