### PR TITLE
Fixing double filters showing up on isd page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+- CMS-1804 - Fixing double filters showing up on ISD search page
 - CMS-1754 - Change /eu-exit-news to /brexit and add redirects
 - CI-400 - Added clickable maps to About Uk landing pages
 - CI-366 - Added cta to invest home page

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -221,7 +221,7 @@ def get_filters_labels(filters):
         'q',
         'page',
         # Prevents duplicates labels not to be displayed in filter list
-        'expertise_products_services_label'
+        'expertise_products_services_labels'
     ]
     for name, values in filters.items():
         if name in skip_fields:

--- a/core/tests/test_helpers.py
+++ b/core/tests/test_helpers.py
@@ -357,7 +357,10 @@ def test_get_filters_labels():
         'page': 5,
         'expertise_regions': ['NORTH_EAST'],
         'expertise_products_services_financial': [expertise.FINANCIAL[1]],
-        'industries': [sectors.AEROSPACE, sectors.ADVANCED_MANUFACTURING]
+        'industries': [sectors.AEROSPACE, sectors.ADVANCED_MANUFACTURING],
+        'expertise_products_services_human_resources': [
+            'Employment and talent research'
+        ]
     }
 
     expected = [
@@ -366,6 +369,7 @@ def test_get_filters_labels():
         'Insurance',
         'Aerospace',
         'Advanced manufacturing',
+        'Employment and talent research',
     ]
 
     assert helpers.get_filters_labels(filters) == expected


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if changing the UI) Add a printscreen to the PR

![image](https://user-images.githubusercontent.com/869769/64624688-f0f26d80-d3e2-11e9-9da0-8ff0e9b802e1.png)
