### PR TITLE
Fixed about uk breadcrumb showing on industry page before page is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - no ticket - Fixed invest contact success going to expand
 - no ticket - Fixed invest going to expand
 - no ticket - Fix 'I want to Buy' URL on industry pages.
+- no ticket = Fixed `About UK` breadcrumb showing before industry pages moved
 
 ## [2019.08.29](https://github.com/uktrade/great-international-ui/releases/tag/2019.08.29)
 [Full Changelog](https://github.com/uktrade/great-international-ui/compare/2019.08.20...2019.08.29)

--- a/core/templates/core/sector_page.html
+++ b/core/templates/core/sector_page.html
@@ -13,7 +13,9 @@
   <div class="container">
       {% breadcrumbs page.heading %}
         <a href="{{ international_home_link.url }}">{{ international_home_link.label }}</a>
-        <a href="{{ about_uk_link }}">{% trans 'About the UK' %}</a>
+        {% if features.INDUSTRIES_REDIRECT_ON %}
+            <a href="{{ about_uk_link }}">{% trans 'About the UK' %}</a>
+        {% endif %}
         <a href="{% url 'industries' %}">{% trans 'Industries' %}</a>
       {% endbreadcrumbs %}
   </div>


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Changelog entry added.
 - [x] (if changing the UI) Add a printscreen to the PR

### Page moved in CMS and redirect on:
![image](https://user-images.githubusercontent.com/43139274/65053826-7dada600-d964-11e9-975a-b1b03ffec4e0.png)

### Page moved in CMS and redirect off/Page in normal place and redirect off:
![image](https://user-images.githubusercontent.com/43139274/65053857-89996800-d964-11e9-9a93-d159dfdde49d.png)
