### PR TITLE
Fix advanced engineering redirect failing if industries redirect is on.

### DIFF
--- a/conf/url_redirects.py
+++ b/conf/url_redirects.py
@@ -13,9 +13,4 @@ redirects = [
         QuerystringRedirectView.as_view(pattern_name='brexit-international-contact-form-success'),
         name='eu-exit-international-contact-form-success'
     ),
-    url(
-        r'^international/content/industries/advanced-manufacturing/$',
-        QuerystringRedirectView.as_view(url='/international/content/industries/engineering-and-manufacturing/'),
-        name='advanced-manufacturing-redirect'
-    ),
 ]

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -121,6 +121,13 @@ elif not settings.FEATURE_FLAGS['EXPAND_REDIRECT_ON'] and settings.FEATURE_FLAGS
         ),
     ]
 
+urlpatterns += [
+    url(
+        r'^international/content/industries/advanced-manufacturing/$',
+        QuerystringRedirectView.as_view(url='/international/content/industries/engineering-and-manufacturing/'),
+        name='advanced-manufacturing-redirect'
+    )
+]
 if settings.FEATURE_FLAGS['INDUSTRIES_REDIRECT_ON']:
     urlpatterns += [
         url(


### PR DESCRIPTION
no changelog as its just a fix to the previous commit.