### PR TITLE
Updated find a supplier form with countries drop down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+- DATAPROJECTS-276 - Updated find a supplier form with countries drop down
 - CI-547 - Remove tariffs section
 - CMS-1787 - Use correct header on Invest pages
 - CI-302 - Added translations for new header

--- a/find_a_supplier/forms.py
+++ b/find_a_supplier/forms.py
@@ -263,13 +263,10 @@ class ContactForm(GovNotifyEmailActionMixin, forms.Form):
         choices=choices.EMPLOYEES,
         required=False,
     )
-    country = forms.CharField(
+    country = forms.ChoiceField(
         label=_('Your country'),
-        max_length=255,
-        validators=[not_contains_url_or_email],
-        widget=TextInput(
-            attrs={'dir': 'auto'}
-        ),
+        choices=[('', 'Please select')] + choices.COUNTRIES_AND_TERRITORIES,
+        widget=Select(attrs={'id': 'js-country-select'}),
     )
     body = forms.CharField(
         label=_('Describe what products or services you need'),
@@ -311,4 +308,5 @@ class ContactForm(GovNotifyEmailActionMixin, forms.Form):
         data = self.cleaned_data.copy()
         del data['captcha']
         del data['terms_agreed']
+        data['country_name'] = dict(choices.COUNTRIES_AND_TERRITORIES)[data['country']]
         return data

--- a/find_a_supplier/tests/conftest.py
+++ b/find_a_supplier/tests/conftest.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
 
 from directory_api_client.client import api_client
+from directory_constants import choices
+
 import pytest
 
 from core.tests.helpers import create_response
@@ -20,6 +22,23 @@ def valid_contact_company_data(captcha_stub):
         'body': 'and salutations',
         'g-recaptcha-response': captcha_stub,
         'terms': True,
+    }
+
+
+@pytest.fixture
+def valid_contact_data(captcha_stub):
+    return {
+        'country': choices.COUNTRIES_AND_TERRITORIES[0][0],
+        'body': 'a',
+        'email_address': 'a@a.com',
+        'full_name': 'a',
+        'organisation_name': 'a',
+        'phone_number': 'a',
+        'sector': choices.sectors.AEROSPACE,
+        'terms_agreed': 'a',
+        'g-recaptcha-response': captcha_stub,
+        'organisation_size': choices.EMPLOYEES[0][0],
+        'source': '',
     }
 
 

--- a/find_a_supplier/tests/test_forms.py
+++ b/find_a_supplier/tests/test_forms.py
@@ -4,6 +4,7 @@ from django.forms.fields import Field
 from unittest import mock
 
 from directory_validators.url import not_contains_url_or_email
+from directory_constants import choices
 
 from find_a_supplier import forms, views
 from core.tests.helpers import create_response
@@ -184,4 +185,70 @@ def test_search_required_empty_sector_term():
 
     assert form.errors == {
         '__all__': [forms.CompanySearchForm.MESSAGE_MISSING_SECTOR_TERM]
+    }
+
+
+def test_contact_required_fields():
+    form = forms.ContactForm(data={}, industry_choices=[])
+
+    assert form.is_valid() is False
+    assert form.errors == {
+        'body': ['This field is required.'],
+        'captcha': ['This field is required.'],
+        'country': ['This field is required.'],
+        'email_address': ['This field is required.'],
+        'full_name': ['This field is required.'],
+        'organisation_name': ['This field is required.'],
+        'phone_number': ['This field is required.'],
+        'sector': ['This field is required.'],
+        'terms_agreed': ['This field is required.']
+    }
+
+
+def test_contact_invalid_country(valid_contact_data):
+    data = valid_contact_data
+    data['country'] = 'fake country'
+    form = forms.ContactForm(
+        data=data,
+        industry_choices=[(forms.choices.sectors.AEROSPACE, 'Aerospace')]
+    )
+
+    assert form.is_valid() is False
+    assert form.errors == {
+        'country': ['Select a valid choice. fake country is not one of the available choices.'],
+    }
+
+
+@mock.patch(
+    'directory_forms_api_client.client.forms_api_client.submit_generic'
+)
+def test_contact_body_text(
+    mock_submit_generic, valid_contact_data
+):
+    mock_submit_generic.return_value = None
+    form = forms.ContactForm(
+        data=valid_contact_data,
+        industry_choices=[(choices.sectors.AEROSPACE, 'Aerospace')]
+    )
+
+    assert form.is_valid()
+
+    form.save(
+        template_id='foo',
+        email_address='reply_to@example.com',
+        form_url='/trade/some/path/',
+    )
+
+    assert form.serialized_data == {
+        'body': valid_contact_data['body'],
+        'country': valid_contact_data['country'],
+        'country_name': choices.COUNTRIES_AND_TERRITORIES[0][1],
+        'email_address': valid_contact_data['email_address'],
+        'organisation_name': valid_contact_data['organisation_name'],
+        'organisation_size': choices.EMPLOYEES[0][1],
+        'sector': choices.sectors.AEROSPACE,
+        'source': '',
+        'source_other': '',
+        'full_name': valid_contact_data['full_name'],
+        'phone_number': valid_contact_data['phone_number']
     }

--- a/find_a_supplier/tests/test_views.py
+++ b/find_a_supplier/tests/test_views.py
@@ -817,7 +817,7 @@ def test_industry_contact_submit_with_comment_forms_api(
         'sector': sectors.AEROSPACE,
         'organisation_name': 'My name is Jeff',
         'organisation_size': '1-10',
-        'country': 'United Kingdom',
+        'country': choices.COUNTRIES_AND_TERRITORIES[1][0],
         'body': 'hello',
         'source': constants.MARKETING_SOURCES[1][0],
         'terms_agreed': True,
@@ -835,7 +835,7 @@ def test_industry_contact_submit_with_comment_forms_api(
         form_url='/international/trade/contact/',
         sender={
             'email_address': 'jeff@example.com',
-            'country_code': 'United Kingdom'
+            'country_code': choices.COUNTRIES_AND_TERRITORIES[1][0]
         },
         spam_control={
             'contents': ['hello']},
@@ -943,21 +943,10 @@ def test_industry_contact_sent_correct_referer(mock_cms_page, client):
 
 
 @mock.patch('directory_forms_api_client.client.forms_api_client.submit_generic')
-def test_industry_contact_serialized_data(mock_submit_generic, captcha_stub):
-    data = {
-        'full_name': 'Jeff',
-        'email_address': 'jeff@example.com',
-        'phone_number': '3223232',
-        'sector': sectors.AEROSPACE,
-        'organisation_name': 'My name is Jeff',
-        'organisation_size': '1-10',
-        'country': 'United Kingdom',
-        'body': 'hello',
-        'source': constants.MARKETING_SOURCES[1][0],
-        'terms_agreed': True,
-        'g-recaptcha-response': captcha_stub,
-    }
-    form = forms.ContactForm(data=data, industry_choices=choices.INDUSTRIES)
+def test_industry_contact_serialized_data(mock_submit_generic, valid_contact_data):
+    mock_submit_generic.return_value = None
+    form = forms.ContactForm(data=valid_contact_data, industry_choices=choices.INDUSTRIES)
+    data = valid_contact_data
 
     assert form.is_valid()
 
@@ -973,8 +962,9 @@ def test_industry_contact_serialized_data(mock_submit_generic, captcha_stub):
         'phone_number': data['phone_number'],
         'sector': data['sector'],
         'organisation_name': data['organisation_name'],
-        'organisation_size': data['organisation_size'],
-        'country': data['country'],
+        'organisation_size': choices.EMPLOYEES[0][1],
+        'country': choices.COUNTRIES_AND_TERRITORIES[0][0],
+        'country_name': choices.COUNTRIES_AND_TERRITORIES[0][1],
         'body': data['body'],
         'source': data['source'],
         'source_other': '',

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ dateparser==0.7.0
 directory-api-client==20.0.0
 directory-cms-client==10.2.0
 directory-components==35.6.2
-directory-constants==20.7.0
+directory-constants==20.10.0
 directory-forms-api-client==5.0.0
 directory-healthcheck==1.1.2
 directory-validators==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ directory-api-client==20.0.0
 directory-client-core==6.1.0  # via directory-api-client, directory-cms-client, directory-forms-api-client, pir-client
 directory-cms-client==10.2.0
 directory-components==35.6.2
-directory-constants==20.7.0
+directory-constants==20.10.0
 directory-forms-api-client==5.0.0
 directory-healthcheck==1.1.2
 directory-validators==6.0.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -20,7 +20,7 @@ directory-api-client==20.0.0
 directory-client-core==6.1.0  # via directory-api-client, directory-cms-client, directory-forms-api-client, pir-client
 directory-cms-client==10.2.0
 directory-components==35.6.2
-directory-constants==20.7.0
+directory-constants==20.10.0
 directory-forms-api-client==5.0.0
 directory-healthcheck==1.1.2
 directory-validators==6.0.0


### PR DESCRIPTION
Updated find a supplier form with countries drop down to use the up-to-date countries and territories list from directory-constants.

 - Directory constants library upgraded


Url to test: http://localhost:8012/international/trade/contact/

Before:
<img width="1092" alt="Screenshot 2019-11-29 at 16 00 25" src="https://user-images.githubusercontent.com/8222658/69880326-953ccf80-12c1-11ea-893e-3264e826f1fe.png">

After:
<img width="1364" alt="Screenshot 2019-11-29 at 15 59 49" src="https://user-images.githubusercontent.com/8222658/69880356-a84f9f80-12c1-11ea-959d-f733dadd3734.png">


To do (delete all that do not apply):

 - [ ] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.

