### PR TITLE
Update euexit form countries option to use countries and territories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+- DATAPROJECTS-258 - Updated euexit form with countries and territories drop down
 - DATAPROJECTS-276 - Updated find a supplier form with countries drop down
 - CI-547 - Remove tariffs section
 - CMS-1787 - Use correct header on Invest pages

--- a/euexit/forms.py
+++ b/euexit/forms.py
@@ -68,7 +68,7 @@ class InternationalContactForm(
     )
     company_name = forms.CharField()
     country = forms.ChoiceField(
-        choices=[('', 'Please select')] + choices.COUNTRY_CHOICES,
+        choices=[('', 'Please select')] + choices.COUNTRIES_AND_TERRITORIES,
         widget=Select(attrs={'id': 'js-country-select'}),
     )
     city = forms.CharField()

--- a/euexit/tests/test_forms.py
+++ b/euexit/tests/test_forms.py
@@ -12,7 +12,7 @@ def international_contact_form_data(captcha_stub):
         'email': 'test@example.com',
         'organisation_type': 'COMPANY',
         'company_name': 'thing',
-        'country': choices.COUNTRY_CHOICES[1][0],
+        'country': choices.COUNTRIES_AND_TERRITORIES[1][0],
         'city': 'London',
         'comment': 'hello',
         'terms_agreed': True,
@@ -47,7 +47,15 @@ def test_contact_form_set_field_attributes():
     assert form_two.fields['terms_agreed'].widget.label.endswith('disclaim')
 
 
-def test_international_contact_form_serialize(captcha_stub):
+@pytest.mark.parametrize(
+    'country_name,form_is_valid,expected_error',
+    (
+        (choices.COUNTRIES_AND_TERRITORIES[2][0], True, None),
+        ('HK', True, None),
+        ('AE-AJ', False, {'country': ['Select a valid choice. AE-AJ is not one of the available choices.']}),
+    )
+)
+def test_international_contact_form_serialize(captcha_stub, country_name, form_is_valid, expected_error):
     form = forms.InternationalContactForm(
         field_attributes={},
         ingress_url='http://www.ingress.com',
@@ -58,7 +66,7 @@ def test_international_contact_form_serialize(captcha_stub):
             'email': 'test@example.com',
             'organisation_type': 'COMPANY',
             'company_name': 'thing',
-            'country': choices.COUNTRY_CHOICES[1][0],
+            'country': country_name,
             'city': 'London',
             'comment': 'hello',
             'terms_agreed': True,
@@ -66,15 +74,18 @@ def test_international_contact_form_serialize(captcha_stub):
         }
     )
 
-    assert form.is_valid()
-    assert form.serialized_data == {
-        'first_name': 'test',
-        'last_name': 'example',
-        'email': 'test@example.com',
-        'organisation_type': 'COMPANY',
-        'company_name': 'thing',
-        'country': choices.COUNTRY_CHOICES[1][0],
-        'city': 'London',
-        'comment': 'hello',
-        'ingress_url': 'http://www.ingress.com',
-    }
+    assert form.is_valid() is form_is_valid
+    if form_is_valid:
+        assert form.serialized_data == {
+            'first_name': 'test',
+            'last_name': 'example',
+            'email': 'test@example.com',
+            'organisation_type': 'COMPANY',
+            'company_name': 'thing',
+            'country': country_name,
+            'city': 'London',
+            'comment': 'hello',
+            'ingress_url': 'http://www.ingress.com',
+        }
+    if expected_error:
+        assert form.errors == expected_error

--- a/euexit/tests/test_views.py
+++ b/euexit/tests/test_views.py
@@ -69,8 +69,15 @@ def test_international_form_cms_retrieval_ok(
 @mock.patch.object(
     views.InternationalContactFormView.form_class, 'save'
 )
+@pytest.mark.parametrize(
+    'country',
+    (
+        choices.COUNTRIES_AND_TERRITORIES[1][0],
+        'HK',
+    )
+)
 def test_international_form_submit(
-        mock_save, mock_lookup_by_slug, settings, client, captcha_stub
+    mock_save, mock_lookup_by_slug, settings, client, captcha_stub, country
 ):
     mock_lookup_by_slug.return_value = create_response(
         status_code=200, json_payload={
@@ -91,7 +98,7 @@ def test_international_form_submit(
         'email': 'test@example.com',
         'organisation_type': 'COMPANY',
         'company_name': 'thing',
-        'country': choices.COUNTRY_CHOICES[1][0],
+        'country': country,
         'city': 'London',
         'comment': 'hello',
         'terms_agreed': True,


### PR DESCRIPTION
Updated euexit form to use the up-to-date countries and territories list from directory-constants.
Effective change, drop down now includes territories including Hong Kong.

To test:
 - Go to http://localhost:8012/international/brexit/contact/ (note view wasn't included in directory-cms fixtures so had to be manually set up)
 - Check drop down includes territories such as Hong Kong
 - Check all functionality works as before


After:
<img width="811" alt="Screenshot 2019-12-02 at 14 54 42" src="https://user-images.githubusercontent.com/8222658/69969943-46877380-1515-11ea-9035-ced3467983ab.png">



To do (delete all that do not apply):

 - [ ] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.


