### PR TITLE
XOT-1266 add specific error messages to the campaign form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+- XOT-1266 - add specific error messsages to the campaign form
 - XOT-1253 - add missing optional fields
 - XOT-1253 and XOT-1260 - add why buy from the uk form and success page, set up for email templates
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -227,7 +227,7 @@ class WhyBuyFromUKForm(GovNotifyEmailActionMixin, forms.BindNestedFormMixin, for
         label=_('Name'),
         error_messages={
             'required': _('Enter your full name'),
-        },
+        }
     )
     email_address = forms.EmailField(
         label=_('Email address'),
@@ -240,19 +240,19 @@ class WhyBuyFromUKForm(GovNotifyEmailActionMixin, forms.BindNestedFormMixin, for
         label=_('Company name'),
         error_messages={
             'required': _('Enter your company name'),
-        },
+        }
     )
     job_title = forms.CharField(
         label=_('Job title'),
         error_messages={
             'required': _('Enter your job title'),
-        },
+        }
     )
     phone_number = forms.CharField(
         label=_('Phone number'),
         error_messages={
             'required': _('Enter your phone number'),
-        },
+        }
     )
     city = forms.CharField(label=_('City (Optional)'), required=False,)
 
@@ -262,7 +262,7 @@ class WhyBuyFromUKForm(GovNotifyEmailActionMixin, forms.BindNestedFormMixin, for
         choices=COUNTRIES,
         error_messages={
             'required': _('Select a country'),
-        },
+        }
     )
 
     procuring_products = forms.RadioNested(
@@ -275,7 +275,7 @@ class WhyBuyFromUKForm(GovNotifyEmailActionMixin, forms.BindNestedFormMixin, for
         nested_form_choice='yes',
         error_messages={
             'required': _('Select either yes or no'),
-        },
+        }
     )
 
     industry = forms.ChoiceField(

--- a/core/forms.py
+++ b/core/forms.py
@@ -216,7 +216,7 @@ class WhyBuyFromUKFormNestedDetails(forms.Form):
     provide_more_info = forms.CharField(
         widget=Textarea,
         label=_('Please provide as much information as possible about the type of'
-                'products or services you’re interested in procuring from the UK. (Optional)'),
+                ' products or services you’re interested in procuring from the UK. (Optional)'),
         help_text=_('The more you tell us, the quicker we can respond and the more relevant our response will be.'),
         required=False,
     )

--- a/core/forms.py
+++ b/core/forms.py
@@ -223,17 +223,46 @@ class WhyBuyFromUKFormNestedDetails(forms.Form):
 
 
 class WhyBuyFromUKForm(GovNotifyEmailActionMixin, forms.BindNestedFormMixin, forms.Form):
-    name = forms.CharField(label=_('Name'))
-    email_address = forms.EmailField(label=_('Email address'))
-    company_name = forms.CharField(label=_('Company name'))
-    job_title = forms.CharField(label=_('Job title'))
-    phone_number = forms.CharField(label=_('Phone number'))
-    city = forms.CharField(label=_('City (Optional)'), required=False)
+    name = forms.CharField(
+        label=_('Name'),
+        error_messages={
+            'required': _('Enter your full name'),
+        },
+    )
+    email_address = forms.EmailField(
+        label=_('Email address'),
+        error_messages={
+            'required': _('Enter an email address in the correct format,'
+                          ' like name@example.com'),
+        }
+    )
+    company_name = forms.CharField(
+        label=_('Company name'),
+        error_messages={
+            'required': _('Enter your company name'),
+        },
+    )
+    job_title = forms.CharField(
+        label=_('Job title'),
+        error_messages={
+            'required': _('Enter your job title'),
+        },
+    )
+    phone_number = forms.CharField(
+        label=_('Phone number'),
+        error_messages={
+            'required': _('Enter your phone number'),
+        },
+    )
+    city = forms.CharField(label=_('City (Optional)'), required=False,)
 
     country = forms.ChoiceField(
         label=_('Country'),
         widget=Select(attrs={'id': 'js-country-select'}),
-        choices=COUNTRIES
+        choices=COUNTRIES,
+        error_messages={
+            'required': _('Select a country'),
+        },
     )
 
     procuring_products = forms.RadioNested(
@@ -244,6 +273,9 @@ class WhyBuyFromUKForm(GovNotifyEmailActionMixin, forms.BindNestedFormMixin, for
         ),
         nested_form_class=WhyBuyFromUKFormNestedDetails,
         nested_form_choice='yes',
+        error_messages={
+            'required': _('Select either yes or no'),
+        },
     )
 
     industry = forms.ChoiceField(


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if changing the UI) Add a printscreen to the PR

![screencapture-international-trade-great-8012-international-trade-how-we-help-you-buy-why-buy-from-the-uk-2019-12-31-12_30_11](https://user-images.githubusercontent.com/36957414/71621797-5902d480-2bc9-11ea-8180-c7234fb2bffa.png)
