### PR TITLE
Fix search icon position

### DIFF
--- a/core/templates/core/companies/base-search.html
+++ b/core/templates/core/companies/base-search.html
@@ -12,7 +12,7 @@
             background-image: url({% static 'core/images/icon-search.png' %});
             background-repeat: no-repeat;
             background-position-y: center;
-            background-position-x: right 15px;
+            background-position-x: calc(100% - 15px);
         }
     </style>
 {% endblock %}


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if adding CSS) CSS have been compiled.
 - [x] (if changing the UI) Add a printscreen to the PR

![image](https://user-images.githubusercontent.com/5485798/72277028-1ad5ce00-3629-11ea-9a13-4e8e68992688.png)

chrome does not support two value position-x: https://caniuse.com/#feat=mdn-css_properties_background-position-x_two_value_syntax

but calc is well supported:

https://caniuse.com/#feat=calc