### PR TITLE
Add missing unsubscribe form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - No ticket - Upgrade waitress to fix security vulnerability
 - TT-2230 - Fix location of ISD homepage in breadcrumbs
 - TT-2237 - Move s3-to-pas (ensure s3 pas is setup in prod and configured AWS_STORAGE_BUCKET_NAME)
+- TT-2249 - Add missing unsubscribe form
 
 ## [2019.12.19](https://github.com/uktrade/great-international-ui/releases/tag/2019.12.19)
 [Full Changelog](https://github.com/uktrade/great-international-ui/compare/2019.12.02...2019.12.19)

--- a/find_a_supplier/forms.py
+++ b/find_a_supplier/forms.py
@@ -311,3 +311,8 @@ class ContactForm(GovNotifyEmailActionMixin, forms.Form):
         del data['terms_agreed']
         data['country_name'] = dict(choices.COUNTRIES_AND_TERRITORIES)[data['country']]
         return data
+
+
+class UnsubscribeForm(forms.Form):
+    # not using EmailField because the value is signed
+    email = forms.CharField(widget=HiddenInput)

--- a/find_a_supplier/redirects.py
+++ b/find_a_supplier/redirects.py
@@ -2,6 +2,7 @@ REDIRECTS = {
     '': '/international/trade/',
     'industries/contact': '/international/trade/contact/',
     'search': '/international/trade/search/',
+    'unsubscribe': '/international/trade/unsubscribe/',
     'industries': '/international/content/industries/',
     'industries/creative-services': '/international/content/industries/creative-industries/',
     'industries/creative': '/international/content/industries/creative-industries/',

--- a/find_a_supplier/templates/find_a_supplier/unsubscribe-failure.html
+++ b/find_a_supplier/templates/find_a_supplier/unsubscribe-failure.html
@@ -1,0 +1,24 @@
+{% extends 'core/base.html' %}
+{% load breadcrumbs from directory_components %}
+
+{% block content %}
+
+<div class="container">
+  {% breadcrumbs 'Failure' %}
+      <a href="{{ trade_home_link.url }}">{{ trade_home_link.label }}</a>
+      <a href="{% url 'find-a-supplier:unsubscribe' %}">Unsubscribe</a>
+  {% endbreadcrumbs %}
+</div>
+
+<section class="padding-bottom-30">
+  <div class="container">
+    <div class="width-two-thirds">
+      <h1 class="heading-large">There was a problem unsubscribing</h1>
+      <p class="ed-international-success-synopsis">
+        Please try again later.
+      </p>
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/find_a_supplier/templates/find_a_supplier/unsubscribe-success.html
+++ b/find_a_supplier/templates/find_a_supplier/unsubscribe-success.html
@@ -1,0 +1,24 @@
+{% extends 'core/base.html' %}
+{% load breadcrumbs from directory_components %}
+
+{% block content %}
+
+<div class="container">
+  {% breadcrumbs 'Success' %}
+      <a href="{{ trade_home_link.url }}">{{ trade_home_link.label }}</a>
+      <a href="{% url 'find-a-supplier:unsubscribe' %}">Unsubscribe</a>
+  {% endbreadcrumbs %}
+</div>
+
+<section class="padding-bottom-30">
+  <div class="container">
+    <div class="width-two-thirds">
+      <h1 class="heading-large">You have successfully unsubscribed from marketing emails from the Find a supplier service</h1>
+      <p class="ed-international-success-synopsis">
+        You may still receive emails about your account, for example, if our terms of use change or there are specific changes to the service(s) offered
+      </p>
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/find_a_supplier/templates/find_a_supplier/unsubscribe.html
+++ b/find_a_supplier/templates/find_a_supplier/unsubscribe.html
@@ -1,0 +1,32 @@
+{% extends 'core/base.html' %}
+{% load breadcrumbs from directory_components %}
+
+{% block content %}
+
+<div class="container">
+  {% breadcrumbs 'Unsubscribe' %}
+      <a href="{{ trade_home_link.url }}">{{ trade_home_link.label }}</a>
+  {% endbreadcrumbs %}
+</div>
+
+<section class="padding-bottom-30">
+  <div class="container">
+    <div class="width-two-thirds">
+      <h1 class="heading-large">Unsubscribe from notifications</h1>
+      <p class="ed-international-success-synopsis">You will no longer receive automated notifications if you unsubscribe.</p>
+      <br>
+      <div class="row-fluid">
+        <form action="" method="post">
+            {{ form }}
+            <div class="row-fluid">
+                <div class="span2 btn-container ed-landing-page-register-button-container">
+                    <button class="button">Unsubscribe</button>
+                </div>
+            </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/find_a_supplier/tests/test_redirects.py
+++ b/find_a_supplier/tests/test_redirects.py
@@ -60,6 +60,7 @@ from django.urls import reverse
     ('industry-articles/a-focus-on-regulatory-technology-solutions-article/',
      '/international/content/industries/financial-services/a-focus-on-regulatory-technology-solutions/'),
     ('industries/infrastructure/', '/international/content/industries/infrastructure/'),
+    ('unsubscribe', '/international/trade/unsubscribe/'),
 ])
 def test_supplier_redirects(source, destination, client):
     url = reverse('trade-incoming', kwargs={'path': source})

--- a/find_a_supplier/tests/test_views.py
+++ b/find_a_supplier/tests/test_views.py
@@ -1,6 +1,6 @@
 import requests
 import pytest
-import http
+
 from unittest import mock
 from unittest.mock import call, patch
 
@@ -693,13 +693,13 @@ def test_home_page_hide_guide(mock_get_results_and_count, client, params):
 def test_anonymous_subscribe(client):
     response = client.get(reverse('find-a-supplier:subscribe'))
 
-    assert response.status_code == http.client.OK
+    assert response.status_code == 200
 
 
 def test_anonymous_subscribe_success(client):
     response = client.get(reverse('find-a-supplier:subscribe-success'))
 
-    assert response.status_code == http.client.OK
+    assert response.status_code == 200
 
 
 @patch('directory_cms_client.client.cms_api_client.lookup_by_path')
@@ -886,3 +886,46 @@ def test_industry_contact_serialized_data(mock_submit_generic, valid_contact_dat
         'source': data['source'],
         'source_other': '',
     }
+
+
+def test_unsubscribe_required_params(client):
+    response = client.get(reverse('find-a-supplier:unsubscribe'), {'email': '123'})
+
+    assert response.status_code == 200
+    assert response.template_name == [views.UnsubscribeView.template_name]
+
+
+def test_unsubscribe_missing_required_params(client):
+    response = client.get(reverse('find-a-supplier:unsubscribe'))
+
+    assert response.status_code == 302
+    assert response.url == reverse('find-a-supplier:trade-home')
+
+
+@patch.object(views.api_client.notifications, 'anonymous_unsubscribe')
+def test_unsubscribe_api_validation_failure(mock_unsubscribe, client):
+    mock_unsubscribe.return_value = create_response(status_code=400)
+
+    response = client.post(reverse('find-a-supplier:unsubscribe'), {'email': '123'})
+
+    assert response.status_code == 200
+    assert response.template_name == views.UnsubscribeView.failure_template_name
+
+
+@patch.object(views.api_client.notifications, 'anonymous_unsubscribe')
+def test_unsubscribe_api_error(mock_unsubscribe, client):
+    mock_unsubscribe.return_value = create_response(status_code=500)
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        client.post(reverse('find-a-supplier:unsubscribe'), {'email': '123'})
+
+
+@patch.object(views.api_client.notifications, 'anonymous_unsubscribe')
+def test_unsubscribe_api_success(mock_unsubscribe, client):
+    mock_unsubscribe.return_value = create_response()
+
+    response = client.post(reverse('find-a-supplier:unsubscribe'), {'email': '123'})
+
+    mock_unsubscribe.assert_called_once_with('123')
+    assert response.status_code == 200
+    assert response.template_name == views.UnsubscribeView.success_template_name

--- a/find_a_supplier/urls.py
+++ b/find_a_supplier/urls.py
@@ -75,4 +75,11 @@ urlpatterns = [
         views.CaseStudyDetailView.as_view(),
         name='case-study-details-slugless'
     ),
+
+    url(
+        r'^unsubscribe/$',
+        views.UnsubscribeView.as_view(),
+        name='unsubscribe'
+    ),
+
 ]

--- a/find_a_supplier/views.py
+++ b/find_a_supplier/views.py
@@ -446,3 +446,46 @@ class IndustryLandingPageContactCMSSuccessView(SpecificRefererRequiredMixin, Bas
     @property
     def expected_referer_url(self):
         return reverse('find-a-supplier:industry-contact', kwargs=self.kwargs)
+
+
+class UnsubscribeView(CountryDisplayMixin, GA360Mixin, FormView):
+    form_class = forms.UnsubscribeForm
+    template_name = 'find_a_supplier/unsubscribe.html'
+    success_template_name = 'find_a_supplier/unsubscribe-success.html'
+    failure_template_name = 'find_a_supplier/unsubscribe-failure.html'
+
+    def __init__(self):
+        super().__init__()
+
+        self.set_ga360_payload(
+            page_id='FindASupplierAnonymousUnsubscribe',
+            business_unit='FindASupplier',
+            site_section='Notifications',
+            site_subsection='AnonymousUnsubscribe'
+        )
+
+    def get_initial(self):
+        if self.request.method == 'GET' and self.request.GET.get('email'):
+            return {'email': self.request.GET['email']}
+        return {}
+
+    def get(self, *args, **kwargs):
+        if not self.request.GET.get('email'):
+            return redirect('find-a-supplier:trade-home')
+        return super().get(*args, **kwargs)
+
+    def form_valid(self, form):
+        response = api_client.notifications.anonymous_unsubscribe(form.cleaned_data['email'])
+        if response.ok:
+            return TemplateResponse(
+                self.request,
+                self.success_template_name,
+                context=self.get_context_data()
+            )
+        elif response.status_code == 400:
+            return TemplateResponse(
+                self.request,
+                self.failure_template_name,
+                context=self.get_context_data()
+            )
+        response.raise_for_status()


### PR DESCRIPTION
We missed this when we copied from FAS to international

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if adding HTML) Change is accessible to the standards we subscribe to.
 - [x] (if changing the UI) Add a printscreen to the PR

## unsubscribe
![Screenshot from 2020-01-13 17-52-50](https://user-images.githubusercontent.com/5485798/72281101-b10df200-3631-11ea-95ec-4866fa39141c.png)

## success
![Screenshot from 2020-01-13 17-53-19](https://user-images.githubusercontent.com/5485798/72281100-b10df200-3631-11ea-9d74-ca19527f564b.png)

## failure
![Screenshot from 2020-01-13 18-04-18](https://user-images.githubusercontent.com/5485798/72281098-b10df200-3631-11ea-94f4-2468b94eb650.png)

## legacy redirect
![redirect](https://user-images.githubusercontent.com/5485798/72281097-b0755b80-3631-11ea-9b8a-ffb73f491f1b.gif)