### PR TITLE
Displays a CTA link on Capital Investment homepage hero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ ENV/
 # Generated files
 ui/staticfiles
 *.css.map
+
+VScode settings
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Pre-release
 
+### Implemented enhancements
+- CI-677 - Display a CTA link on Capital Investment homepage hero
+
 ## Hotfix
 - No ticket - v3 ci pipeline manifest.yml file fix
 

--- a/core/templates/core/capital_invest/capital_invest_landing_page.html
+++ b/core/templates/core/capital_invest/capital_invest_landing_page.html
@@ -8,7 +8,8 @@
 
 {% block content %}
 
-{% cms_hero_with_cta heading=page.hero_title subheading=page.hero_subheading subtitle=page.hero_subtitle cta_text=page.hero_cta_text cta_link=page.hero_cta_link %}
+{% url 'how-to-do-business-with-the-uk' as doing_business_url %}
+{% cms_hero_with_cta heading=page.hero_title subheading=page.hero_subheading subtitle=page.hero_subtitle cta_text=page.hero_cta_text cta_link=page.hero_cta_link|default:doing_business_url %}
 
 {% if 'breadcrumbs_label' in page and page.breadcrumbs_label %}
 <div class="container">

--- a/core/templates/core/capital_invest/capital_invest_landing_page.html
+++ b/core/templates/core/capital_invest/capital_invest_landing_page.html
@@ -8,8 +8,7 @@
 
 {% block content %}
 
-{% url 'how-to-do-business-with-the-uk' as doing_business_url %}
-{% cms_hero_with_cta heading=page.hero_title subheading=page.hero_subheading subtitle=page.hero_subtitle cta_text=page.hero_cta_text cta_link=doing_business_url %}
+{% cms_hero_with_cta heading=page.hero_title subheading=page.hero_subheading subtitle=page.hero_subtitle cta_text=page.hero_cta_text cta_link=page.hero_cta_link %}
 
 {% if 'breadcrumbs_label' in page and page.breadcrumbs_label %}
 <div class="container">


### PR DESCRIPTION
As https://github.com/uktrade/directory-cms/pull/820 adds a new "Hero cta link" field to the Capital Investment homepage, this ticket is adding that link to the Hero button as you can see on the screenshot, the very bottom is showing the link when I hover the mouse over "Get in touch" button 

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
 - [X] (if changing the UI) Add a printscreen to the PR

![image](https://user-images.githubusercontent.com/2598484/79318493-f7a80c80-7efe-11ea-8482-356688883b27.png)
