### PR TITLE
TT-2342 / Broken link change

### DIFF
--- a/euexit/templates/euexit/form-contents.html
+++ b/euexit/templates/euexit/form-contents.html
@@ -8,7 +8,7 @@
             <div class="margin-bottom-45">
               {% blocktrans %}
               <p>
-                See our guidance on <a class="link" href="{{ services_urls.international }}/content/invest/how-to-setup-in-the-uk/transition-period/">trading with the UK during the transition period and in 2021</a>. If you can’t find the information you’re looking for, complete the form below and one of our experts will try to help you.
+                See our guidance on <a class="link" href="{{ services_urls.international }}/international/content/invest/how-to-setup-in-the-uk/transition-period/">trading with the UK during the transition period and in 2021</a>. If you can’t find the information you’re looking for, complete the form below and one of our experts will try to help you.
               </p>
               {% endblocktrans %}
             </div>


### PR DESCRIPTION
Changed from: 
https://www.great.gov.uk/content/invest/how-to-setup-in-the-uk/transition-period/ [Broken link]
to 
https://www.great.gov.uk/international/content/invest/how-to-setup-in-the-uk/transition-period/ [Live link]

To do (delete all that do not apply):

 https://uktrade.atlassian.net/browse/TT-2342