### PR TITLE
TT-2372 : Switch country selectors to country and territory "markets"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - TT-2236 Spanish Translation on great international
 - chore/python-gevent adding gevent asyncio for performance
+- Replace the country field with a new "countries and territories" field for two forms:
+  - Why buy from the uk
+  - Business environment guide
 
 ## Pre-release
 

--- a/core/forms.py
+++ b/core/forms.py
@@ -11,13 +11,14 @@ from directory_validators.string import no_html
 from captcha.fields import ReCaptchaField
 
 
-from directory_constants.choices import COUNTRY_CHOICES, INDUSTRIES
+from directory_constants.choices import COUNTRIES_AND_TERRITORIES, COUNTRY_CHOICES, INDUSTRIES
 
 from django.conf import settings
 from core import constants
 
 COUNTRIES = BLANK_CHOICE_DASH + COUNTRY_CHOICES
 INDUSTRY_OPTIONS = BLANK_CHOICE_DASH + list(INDUSTRIES)
+COUNTRIES_AND_TERRITORIES = BLANK_CHOICE_DASH + COUNTRIES_AND_TERRITORIES
 
 
 class TariffsCountryForm(forms.Form):
@@ -139,10 +140,9 @@ class BusinessEnvironmentGuideForm(GovNotifyEmailActionMixin, forms.Form):
     family_name = forms.CharField(label=_('Family name'), required=True)
     email_address = forms.EmailField(label=_('Email address'), required=True)
     phone_number = forms.CharField(label=_('Phone number'), required=True)
-    country = forms.ChoiceField(
-        label=_('Country'),
-        widget=Select(attrs={'id': 'js-country-select'}),
-        choices=COUNTRIES
+    market = forms.ChoiceField(
+        label=_('What market are you in?'),
+        choices=COUNTRIES_AND_TERRITORIES,
     )
     company_name = forms.CharField(label=_('Company name'), required=True)
     industry = forms.ChoiceField(
@@ -214,12 +214,11 @@ class WhyBuyFromUKForm(GovNotifyEmailActionMixin, forms.BindNestedFormMixin, for
     )
     city = forms.CharField(label=_('City (Optional)'), required=False,)
 
-    country = forms.ChoiceField(
-        label=_('Your country'),
-        widget=Select(attrs={'id': 'js-country-select'}),
-        choices=COUNTRIES,
+    market = forms.ChoiceField(
+        label=_('What market are you in?'),
+        choices=COUNTRIES_AND_TERRITORIES,
         error_messages={
-            'required': _('Select a country'),
+            'required': _('Select a market'),
         }
     )
 

--- a/core/templates/core/investment_prospectus_form.html
+++ b/core/templates/core/investment_prospectus_form.html
@@ -32,7 +32,7 @@
                         {% include 'core/includes/form_field.html' with field=form.family_name %}
                         {% include 'core/includes/form_field.html' with field=form.email_address %}
                         {% include 'core/includes/form_field.html' with field=form.phone_number %}
-                        {% include 'core/includes/form_field.html' with field=form.country %}
+                        {% include 'core/includes/form_field.html' with field=form.market %}
                         {% include 'core/includes/form_field.html' with field=form.company_name %}
                         {% include 'core/includes/form_field.html' with field=form.industry %}
 

--- a/core/templates/core/why_buy_from_the_uk_form.html
+++ b/core/templates/core/why_buy_from_the_uk_form.html
@@ -37,7 +37,7 @@
                         {% include 'directory_components/form_widgets/form_field.html' with field=form.phone_number %}
                         {% include 'directory_components/form_widgets/form_field.html' with field=form.job_title %}
                         {% include 'directory_components/form_widgets/form_field.html' with field=form.city %}
-                        {% include 'directory_components/form_widgets/form_field.html' with field=form.country %}
+                        {% include 'directory_components/form_widgets/form_field.html' with field=form.market %}
 
 
                         {% include 'directory_components/form_widgets/form_field.html' with field=form.procuring_products %}

--- a/core/tests/test_forms.py
+++ b/core/tests/test_forms.py
@@ -34,7 +34,7 @@ def business_environment_form_data(captcha_stub):
         'family_name': 'Odinson',
         'email_address': 'most_powerful_avenger@avengers.com',
         'phone_number': '01234567899',
-        'country': 'FR',
+        'market': 'FR',
         'company_name': 'Guardian of the Galaxy',
         'industry': 'ADVANCED_MANUFACTURING',
         'email_contact_consent': True,
@@ -101,7 +101,7 @@ def test_business_environment_form_required():
     assert form.fields['family_name'].required is True
     assert form.fields['email_address'].required is True
     assert form.fields['phone_number'].required is True
-    assert form.fields['country'].required is True
+    assert form.fields['market'].required is True
     assert form.fields['company_name'].required is True
     assert form.fields['industry'].required is True
     assert form.fields['email_contact_consent'].required is False
@@ -119,7 +119,7 @@ def test_business_environment_serialized_data(business_environment_form_data):
     assert 'family_name' in data
     assert 'email_address' in data
     assert 'phone_number' in data
-    assert 'country' in data
+    assert 'market' in data
     assert 'company_name' in data
     assert 'industry' in data
     assert 'email_contact_consent' in data
@@ -152,7 +152,7 @@ def why_buy_from_the_uk_form_data(captcha_stub):
         'company_name': 'Company LTD',
         'job_title': 'Director',
         'phone_number': '07777777777',
-        'country': 'FR',
+        'market': 'FR',
         'industry': 'ADVANCED_MANUFACTURING',
         'procuring_products': 'yes',
         'contact_email': False,
@@ -172,7 +172,7 @@ def test_why_buy_from_the_uk_form_required():
     assert form.fields['phone_number'].required is False
     assert form.fields['city'].required is False
     assert form.fields['industry'].required is False
-    assert form.fields['country'].required is True
+    assert form.fields['market'].required is True
     assert form.fields['procuring_products'].required is True
     assert form.fields['contact_email'].required is False
     assert form.fields['contact_phone'].required is False
@@ -197,7 +197,7 @@ def test_why_buy_from_the_uk_form_serialized_data(why_buy_from_the_uk_form_data)
     assert 'provide_more_info' in data
     assert 'contact_phone' in data
     assert 'contact_email' in data
-    assert 'country' in data
+    assert 'market' in data
     assert 'city' in data
 
 

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -2787,7 +2787,7 @@ def why_buy_from_uk_form_data(captcha_stub):
         'company_name': 'Company LTD',
         'job_title': 'Director',
         'phone_number': '07777777777',
-        'country': 'FR',
+        'market': 'FR',
         'industry': 'ADVANCED_MANUFACTURING',
         'procuring_products': 'yes',
         'contact_email': False,

--- a/core/views.py
+++ b/core/views.py
@@ -889,7 +889,7 @@ class BusinessEnvironmentGuideFormView(EnableTranslationsMixin, GA360Mixin, Inte
     def send_agent_email(self, form):
         sender = directory_forms_api_client.helpers.Sender(
             email_address=form.cleaned_data['email_address'],
-            country_code=form.cleaned_data['country'],
+            country_code=form.cleaned_data['market'],
         )
         response = form.save(
             form_url=self.request.path,

--- a/core/views.py
+++ b/core/views.py
@@ -955,7 +955,7 @@ class WhyBuyFromUKFormView(GA360Mixin, EnableTranslationsMixin, InternationalHea
     def send_agent_email(self, form):
         sender = directory_forms_api_client.helpers.Sender(
             email_address=form.cleaned_data['email_address'],
-            country_code=form.cleaned_data['country'],
+            country_code=form.cleaned_data['market'],
         )
         response = form.save(
             form_url=self.request.get_full_path(),

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-20 15:48+0000\n"
+"POT-Creation-Date: 2020-08-26 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: contact/forms.py:20 core/forms.py:230
+#: contact/forms.py:20 core/forms.py:229
 msgid "Yes"
 msgstr "Ja"
 
-#: contact/forms.py:21 core/forms.py:231
+#: contact/forms.py:21 core/forms.py:230
 msgid "No"
 msgstr "Nein"
 
@@ -34,7 +34,7 @@ msgstr "Pressewerbung (Zeitung/Fachzeitschrift)"
 msgid "Outdoor ad/billboard"
 msgstr "Außenwerbung/Plakate"
 
-#: contact/forms.py:26
+#: contact/forms.py:26 invest/forms.py:16
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
@@ -42,11 +42,12 @@ msgstr "LinkedIn"
 msgid "Other social media (e.g. Twitter/Facebook)"
 msgstr "Andere soziale Medien (z. B. Twitter/Facebook)"
 
-#: contact/forms.py:28
+#: contact/forms.py:28 invest/forms.py:18
 msgid "Internet search"
 msgstr "Internetrecherche"
 
-#: contact/forms.py:29 core/forms.py:293 find_a_supplier/constants.py:38
+#: contact/forms.py:29 core/forms.py:292 find_a_supplier/constants.py:38
+#: invest/forms.py:19
 msgid "Other"
 msgstr "Sonstiges"
 
@@ -83,47 +84,49 @@ msgstr "Am Morgen"
 msgid "In the afternoon"
 msgstr "Am Nachmittag"
 
-#: contact/forms.py:76 contact/forms.py:145 core/forms.py:96 core/forms.py:138
-#: core/forms.py:183 euexit/forms.py:50 find_a_supplier/forms.py:224
+#: contact/forms.py:76 contact/forms.py:145 core/forms.py:97 core/forms.py:139
+#: core/forms.py:183 euexit/forms.py:50 find_a_supplier/forms.py:227
+#: invest/forms.py:53
 msgid "Given name"
 msgstr "Vorname"
 
-#: contact/forms.py:77 contact/forms.py:146 core/forms.py:97 core/forms.py:139
-#: core/forms.py:189 euexit/forms.py:51 find_a_supplier/forms.py:232
+#: contact/forms.py:77 contact/forms.py:146 core/forms.py:98 core/forms.py:140
+#: core/forms.py:189 euexit/forms.py:51 find_a_supplier/forms.py:235
+#: invest/forms.py:56
 msgid "Family name"
 msgstr "Familienname"
 
-#: contact/forms.py:78 contact/forms.py:147
+#: contact/forms.py:78 contact/forms.py:147 invest/forms.py:59
 msgid "Job title"
 msgstr "Position"
 
-#: contact/forms.py:79
+#: contact/forms.py:79 invest/forms.py:62
 msgid "Work email address"
 msgstr "E-Mail-Adresse"
 
-#: contact/forms.py:81 contact/forms.py:149 core/forms.py:141
-#: find_a_supplier/forms.py:246
+#: contact/forms.py:81 contact/forms.py:149 core/forms.py:142
+#: find_a_supplier/forms.py:249 invest/forms.py:65
 msgid "Phone number"
 msgstr "Telefonnummer"
 
 #: contact/forms.py:83 contact/forms.py:150 core/forms.py:147 core/forms.py:202
-#: euexit/forms.py:58 find_a_supplier/forms.py:187
+#: euexit/forms.py:58 find_a_supplier/forms.py:190 invest/forms.py:68
 msgid "Company name"
 msgstr "Unternehmen"
 
-#: contact/forms.py:85 contact/forms.py:151
+#: contact/forms.py:85 contact/forms.py:151 invest/forms.py:71
 msgid "Company website"
 msgstr "Unternehmens-Website"
 
-#: contact/forms.py:88 contact/forms.py:152
+#: contact/forms.py:88 contact/forms.py:152 invest/forms.py:74
 msgid "Company HQ address"
 msgstr "Adresse des Unternehmenssitzes"
 
-#: contact/forms.py:91 core/forms.py:104 euexit/forms.py:60
+#: contact/forms.py:91 core/forms.py:105 euexit/forms.py:60 invest/forms.py:78
 msgid "Which country are you based in?"
 msgstr "In welchem Land befinden Sie sich?"
 
-#: contact/forms.py:96 find_a_supplier/forms.py:252
+#: contact/forms.py:96 find_a_supplier/forms.py:255 invest/forms.py:83
 msgid "Your industry"
 msgstr "Ihre Branche"
 
@@ -152,20 +155,20 @@ msgstr ""
 msgid "Would you like to arrange a call?"
 msgstr "Möchten Sie einen Anruf vereinbaren?"
 
-#: contact/forms.py:120 contact/forms.py:159
+#: contact/forms.py:120 contact/forms.py:159 invest/forms.py:105
 msgid "How did you hear about us?"
 msgstr "Wie haben Sie von uns erfahren?"
 
-#: contact/forms.py:148 core/forms.py:98 core/forms.py:140 core/forms.py:195
-#: euexit/forms.py:52 find_a_supplier/forms.py:179 find_a_supplier/forms.py:240
+#: contact/forms.py:148 core/forms.py:99 core/forms.py:141 core/forms.py:195
+#: euexit/forms.py:52 find_a_supplier/forms.py:182 find_a_supplier/forms.py:243
 msgid "Email address"
 msgstr "E-Mail-Adresse"
 
-#: contact/forms.py:153 core/forms.py:143 perfect_fit_prospectus/forms.py:32
+#: contact/forms.py:153 perfect_fit_prospectus/forms.py:32
 msgid "Country"
 msgstr "Land"
 
-#: contact/forms.py:154 core/forms.py:149 find_a_supplier/forms.py:181
+#: contact/forms.py:154 core/forms.py:149 find_a_supplier/forms.py:184
 msgid "Industry"
 msgstr "Branche"
 
@@ -204,6 +207,7 @@ msgstr "Ihre Investition"
 #: core/templates/core/investment_prospectus_form.html:42
 #: core/templates/core/why_buy_from_the_uk_form.html:54
 #: euexit/templates/euexit/form-contents.html:32
+#: invest/templates/invest/hpo/high_potential_opportunities_form.html:52
 msgid "Submit"
 msgstr "Absenden"
 
@@ -240,31 +244,31 @@ msgstr "Ich möchte weitere Informationen per E-Mail erhalten"
 msgid "I would like to receive additional information by telephone"
 msgstr "Ich möchte weitere Informationen per Telefon erhalten"
 
-#: core/constants.py:292
+#: core/constants.py:296
 msgid "1-10"
 msgstr "1 bis 10"
 
-#: core/constants.py:293
+#: core/constants.py:297
 msgid "11-50"
 msgstr "11 bis 50"
 
-#: core/constants.py:294
+#: core/constants.py:298
 msgid "51-200"
 msgstr "51 bis 200"
 
-#: core/constants.py:295
+#: core/constants.py:299
 msgid "201-500"
 msgstr "201 bis 500"
 
-#: core/constants.py:296
+#: core/constants.py:300
 msgid "501-1,000"
 msgstr "501 bis 1.000"
 
-#: core/constants.py:297
+#: core/constants.py:301
 msgid "1,001-10,000"
 msgstr "1.001 bis 10.000"
 
-#: core/constants.py:298
+#: core/constants.py:302
 msgid "10,001+"
 msgstr "Mehr als 10.000"
 
@@ -280,17 +284,21 @@ msgstr "Anbieter finden"
 msgid "Invest"
 msgstr ""
 
-#: core/forms.py:100 core/forms.py:212
+#: core/forms.py:101 core/forms.py:212
 msgid "Phone number (Optional)"
 msgstr "Telefonnummer (optional)"
 
-#: core/forms.py:109
+#: core/forms.py:110
 msgid "Message"
 msgstr "Nachricht"
 
-#: core/forms.py:113
+#: core/forms.py:114 invest/forms.py:96
 msgid "How can we help?"
 msgstr "Wie können wir helfen?"
+
+#: core/forms.py:144 core/forms.py:218
+msgid "What market are you in?"
+msgstr ""
 
 #: core/forms.py:175
 msgid ""
@@ -321,15 +329,11 @@ msgstr "Position (optional)"
 msgid "City (Optional)"
 msgstr "Stadt (optional)"
 
-#: core/forms.py:218 find_a_supplier/forms.py:269
-msgid "Your country"
-msgstr "Ihr Land"
-
-#: core/forms.py:222
-msgid "Select a country"
+#: core/forms.py:221
+msgid "Select a market"
 msgstr ""
 
-#: core/forms.py:227
+#: core/forms.py:226
 msgid ""
 "Are you interested in buying products or services from UK businesses, either "
 "now or in the near future?"
@@ -337,31 +341,31 @@ msgstr ""
 "Möchten Sie jetzt oder in naher Zukunft Produkte oder Dienstleistungen von "
 "britischen Unternehmen kaufen?"
 
-#: core/forms.py:236
+#: core/forms.py:235
 msgid "Select either yes or no"
 msgstr ""
 
-#: core/forms.py:241
+#: core/forms.py:240
 msgid "Your industry (optional)"
 msgstr "Ihre Branche (optional)"
 
-#: core/forms.py:288
+#: core/forms.py:287
 msgid "Expanding to the UK"
 msgstr "Expansion nach Großbritannien"
 
-#: core/forms.py:289
+#: core/forms.py:288
 msgid "Investing capital in the UK"
 msgstr "Kapitalinvestitionen in Großbritannien"
 
-#: core/forms.py:290
+#: core/forms.py:289
 msgid "Exporting to the UK"
 msgstr ""
 
-#: core/forms.py:291
+#: core/forms.py:290
 msgid "Buying from the UK"
 msgstr "Handel mit Großbritannien"
 
-#: core/forms.py:292
+#: core/forms.py:291
 msgid "The transition period (now that the UK has left the EU)"
 msgstr ""
 "Die Übergangsphase (die Phase nach dem Austritt Großbritanniens aus der EU)"
@@ -585,6 +589,12 @@ msgstr ""
 "erhalten möchten, können Sie sich unten anmelden. Sie können sich von diesen "
 "Aktualisierungen jederzeit wieder abmelden."
 
+#: core/templates/core/includes/form_consent_hpo.html:7
+msgid ""
+"If you would like to receive additional information about expanding to the "
+"UK you can opt in below. You can opt out of these updates at any time."
+msgstr ""
+
 #: core/templates/core/includes/form_consent_invest.html:7
 msgid ""
 "If you would like to receive additional information about investing in the "
@@ -757,23 +767,13 @@ msgid ""
 "\n"
 "              <p>\n"
 "                See our guidance on <a class=\"link\" href="
-"\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
-"transition-period/\">trading with the UK during the transition period and in "
-"2021</a>. If you can’t find the information you’re looking for, complete the "
-"form below and one of our experts will try to help you.\n"
+"\"%(services_urls.international)s/international/content/invest/how-to-setup-"
+"in-the-uk/transition-period/\">trading with the UK during the transition "
+"period and in 2021</a>. If you can’t find the information you’re looking "
+"for, complete the form below and one of our experts will try to help you.\n"
 "              </p>\n"
 "              "
 msgstr ""
-"\n"
-"              <p>\n"
-"                Sehen Sie sich unsere Informationen zum <a class=\"link\" "
-"href=\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
-"transition-period/\">Handel mit Großbritannien während der Übergangsphase "
-"und im Jahr 2021</a> an. Sollten Sie die gewünschten Informationen nicht "
-"finden, füllen Sie das Formular unten aus. Einer unserer Experten wird Ihnen "
-"Auskunft geben.\n"
-"              </p>\n"
-"              "
 
 #: find_a_supplier/constants.py:7
 msgid "Magazines, newspaper or trade press"
@@ -807,40 +807,73 @@ msgstr "Bei einer Veranstaltung"
 msgid "All industries"
 msgstr "Branchen"
 
-#: find_a_supplier/forms.py:169
+#: find_a_supplier/forms.py:172
 msgid "Please select an industry"
 msgstr ""
 
-#: find_a_supplier/forms.py:171
+#: find_a_supplier/forms.py:174
 msgid "Tick the box to confirm you agree to the terms and conditions."
 msgstr ""
 
-#: find_a_supplier/forms.py:178
+#: find_a_supplier/forms.py:181
 msgid "Your name"
 msgstr ""
 
-#: find_a_supplier/forms.py:256
+#: find_a_supplier/forms.py:259
 msgid "Your organisation name"
 msgstr "Name Ihrer Organisation"
 
-#: find_a_supplier/forms.py:264
+#: find_a_supplier/forms.py:267
 msgid "Size of your organisation"
 msgstr "Größe Ihrer Organisation"
 
-#: find_a_supplier/forms.py:274
+#: find_a_supplier/forms.py:272
+msgid "Your country"
+msgstr "Ihr Land"
+
+#: find_a_supplier/forms.py:277
 msgid "Describe what products or services you need"
 msgstr "Beschreiben Sie, welche Produkte oder Dienstleistungen Sie benötigen"
 
-#: find_a_supplier/forms.py:275
+#: find_a_supplier/forms.py:278
 msgid "Maximum 1000 characters."
 msgstr "Maximal 1.000 Zeichen"
 
-#: find_a_supplier/forms.py:283
+#: find_a_supplier/forms.py:286
 msgid "Where did you hear about great.gov.uk?"
 msgstr "Wo haben Sie von great.gov.uk erfahren?"
 
-#: find_a_supplier/forms.py:292
+#: find_a_supplier/forms.py:295
 msgid "Other source (optional)"
+msgstr ""
+
+#: invest/forms.py:14
+msgid "Advert in a publication"
+msgstr ""
+
+#: invest/forms.py:15
+msgid "Billboard or other outdoor advert"
+msgstr ""
+
+#: invest/forms.py:17
+msgid "Other social media"
+msgstr ""
+
+#: invest/forms.py:25
+msgid "I'm ready to invest and I'd like an adviser to call me."
+msgstr ""
+
+#: invest/forms.py:29
+msgid ""
+"I'm not quite ready to invest but I'd like to get updates on opportunities."
+msgstr ""
+
+#: invest/forms.py:88
+msgid "Which opportunities are you interested in?"
+msgstr ""
+
+#: invest/forms.py:101
+msgid "Tell us about your plans"
 msgstr ""
 
 #: perfect_fit_prospectus/forms.py:12
@@ -897,3 +930,25 @@ msgstr ""
 #, python-format
 msgid "Thank You. Your Perfect Fit Prospectus has been emailed to %(email)s"
 msgstr ""
+
+#~ msgid ""
+#~ "\n"
+#~ "              <p>\n"
+#~ "                See our guidance on <a class=\"link\" href="
+#~ "\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
+#~ "transition-period/\">trading with the UK during the transition period and "
+#~ "in 2021</a>. If you can’t find the information you’re looking for, "
+#~ "complete the form below and one of our experts will try to help you.\n"
+#~ "              </p>\n"
+#~ "              "
+#~ msgstr ""
+#~ "\n"
+#~ "              <p>\n"
+#~ "                Sehen Sie sich unsere Informationen zum <a class=\"link\" "
+#~ "href=\"%(services_urls.international)s/content/invest/how-to-setup-in-the-"
+#~ "uk/transition-period/\">Handel mit Großbritannien während der "
+#~ "Übergangsphase und im Jahr 2021</a> an. Sollten Sie die gewünschten "
+#~ "Informationen nicht finden, füllen Sie das Formular unten aus. Einer "
+#~ "unserer Experten wird Ihnen Auskunft geben.\n"
+#~ "              </p>\n"
+#~ "              "

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-20 15:48+0000\n"
+"POT-Creation-Date: 2020-08-26 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: contact/forms.py:20 core/forms.py:230
+#: contact/forms.py:20 core/forms.py:229
 msgid "Yes"
 msgstr ""
 
-#: contact/forms.py:21 core/forms.py:231
+#: contact/forms.py:21 core/forms.py:230
 msgid "No"
 msgstr ""
 
@@ -34,7 +34,7 @@ msgstr "Publicidad en prensa (publicación en un periódico/comercial)"
 msgid "Outdoor ad/billboard"
 msgstr "Publicidad exterior/valla publicitaria"
 
-#: contact/forms.py:26
+#: contact/forms.py:26 invest/forms.py:16
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
@@ -42,11 +42,12 @@ msgstr "LinkedIn"
 msgid "Other social media (e.g. Twitter/Facebook)"
 msgstr "Otras redes sociales (p. ej., Twitter/Facebook)"
 
-#: contact/forms.py:28
+#: contact/forms.py:28 invest/forms.py:18
 msgid "Internet search"
 msgstr "Búsqueda en Internet"
 
-#: contact/forms.py:29 core/forms.py:293 find_a_supplier/constants.py:38
+#: contact/forms.py:29 core/forms.py:292 find_a_supplier/constants.py:38
+#: invest/forms.py:19
 msgid "Other"
 msgstr "Otros"
 
@@ -86,47 +87,49 @@ msgstr "Por la mañana"
 msgid "In the afternoon"
 msgstr "Por la tarde"
 
-#: contact/forms.py:76 contact/forms.py:145 core/forms.py:96 core/forms.py:138
-#: core/forms.py:183 euexit/forms.py:50 find_a_supplier/forms.py:224
+#: contact/forms.py:76 contact/forms.py:145 core/forms.py:97 core/forms.py:139
+#: core/forms.py:183 euexit/forms.py:50 find_a_supplier/forms.py:227
+#: invest/forms.py:53
 msgid "Given name"
 msgstr "Nombre"
 
-#: contact/forms.py:77 contact/forms.py:146 core/forms.py:97 core/forms.py:139
-#: core/forms.py:189 euexit/forms.py:51 find_a_supplier/forms.py:232
+#: contact/forms.py:77 contact/forms.py:146 core/forms.py:98 core/forms.py:140
+#: core/forms.py:189 euexit/forms.py:51 find_a_supplier/forms.py:235
+#: invest/forms.py:56
 msgid "Family name"
 msgstr "Apellidos"
 
-#: contact/forms.py:78 contact/forms.py:147
+#: contact/forms.py:78 contact/forms.py:147 invest/forms.py:59
 msgid "Job title"
 msgstr "Cargo"
 
-#: contact/forms.py:79
+#: contact/forms.py:79 invest/forms.py:62
 msgid "Work email address"
 msgstr "Dirección de correo electrónico"
 
-#: contact/forms.py:81 contact/forms.py:149 core/forms.py:141
-#: find_a_supplier/forms.py:246
+#: contact/forms.py:81 contact/forms.py:149 core/forms.py:142
+#: find_a_supplier/forms.py:249 invest/forms.py:65
 msgid "Phone number"
 msgstr "Número de teléfono"
 
 #: contact/forms.py:83 contact/forms.py:150 core/forms.py:147 core/forms.py:202
-#: euexit/forms.py:58 find_a_supplier/forms.py:187
+#: euexit/forms.py:58 find_a_supplier/forms.py:190 invest/forms.py:68
 msgid "Company name"
 msgstr "Nombre de la empresa"
 
-#: contact/forms.py:85 contact/forms.py:151
+#: contact/forms.py:85 contact/forms.py:151 invest/forms.py:71
 msgid "Company website"
 msgstr "Sitio web de la empresa"
 
-#: contact/forms.py:88 contact/forms.py:152
+#: contact/forms.py:88 contact/forms.py:152 invest/forms.py:74
 msgid "Company HQ address"
 msgstr "Dirección de la sede de la empresa"
 
-#: contact/forms.py:91 core/forms.py:104 euexit/forms.py:60
+#: contact/forms.py:91 core/forms.py:105 euexit/forms.py:60 invest/forms.py:78
 msgid "Which country are you based in?"
 msgstr "¿En qué país se encuentra?"
 
-#: contact/forms.py:96 find_a_supplier/forms.py:252
+#: contact/forms.py:96 find_a_supplier/forms.py:255 invest/forms.py:83
 msgid "Your industry"
 msgstr "Su sector"
 
@@ -155,20 +158,20 @@ msgstr ""
 msgid "Would you like to arrange a call?"
 msgstr "¿Desea concertar una llamada?"
 
-#: contact/forms.py:120 contact/forms.py:159
+#: contact/forms.py:120 contact/forms.py:159 invest/forms.py:105
 msgid "How did you hear about us?"
 msgstr "¿Cómo nos ha conocido?"
 
-#: contact/forms.py:148 core/forms.py:98 core/forms.py:140 core/forms.py:195
-#: euexit/forms.py:52 find_a_supplier/forms.py:179 find_a_supplier/forms.py:240
+#: contact/forms.py:148 core/forms.py:99 core/forms.py:141 core/forms.py:195
+#: euexit/forms.py:52 find_a_supplier/forms.py:182 find_a_supplier/forms.py:243
 msgid "Email address"
 msgstr "Dirección de correo electrónico de la empresa"
 
-#: contact/forms.py:153 core/forms.py:143 perfect_fit_prospectus/forms.py:32
+#: contact/forms.py:153 perfect_fit_prospectus/forms.py:32
 msgid "Country"
 msgstr "País"
 
-#: contact/forms.py:154 core/forms.py:149 find_a_supplier/forms.py:181
+#: contact/forms.py:154 core/forms.py:149 find_a_supplier/forms.py:184
 msgid "Industry"
 msgstr "Sector"
 
@@ -207,6 +210,7 @@ msgstr "Su inversión"
 #: core/templates/core/investment_prospectus_form.html:42
 #: core/templates/core/why_buy_from_the_uk_form.html:54
 #: euexit/templates/euexit/form-contents.html:32
+#: invest/templates/invest/hpo/high_potential_opportunities_form.html:52
 msgid "Submit"
 msgstr "Enviar"
 
@@ -241,31 +245,31 @@ msgstr "Me gustaría recibir información adicional por correo electrónico"
 msgid "I would like to receive additional information by telephone"
 msgstr "Me gustaría recibir información adicional por teléfono"
 
-#: core/constants.py:292
+#: core/constants.py:296
 msgid "1-10"
 msgstr ""
 
-#: core/constants.py:293
+#: core/constants.py:297
 msgid "11-50"
 msgstr ""
 
-#: core/constants.py:294
+#: core/constants.py:298
 msgid "51-200"
 msgstr ""
 
-#: core/constants.py:295
+#: core/constants.py:299
 msgid "201-500"
 msgstr ""
 
-#: core/constants.py:296
+#: core/constants.py:300
 msgid "501-1,000"
 msgstr "501-1.000"
 
-#: core/constants.py:297
+#: core/constants.py:301
 msgid "1,001-10,000"
 msgstr "1.001-10.000"
 
-#: core/constants.py:298
+#: core/constants.py:302
 msgid "10,001+"
 msgstr "Más de 10.000"
 
@@ -281,17 +285,21 @@ msgstr "Buscar un proveedor"
 msgid "Invest"
 msgstr ""
 
-#: core/forms.py:100 core/forms.py:212
+#: core/forms.py:101 core/forms.py:212
 msgid "Phone number (Optional)"
 msgstr "Número de teléfono de la empresa"
 
-#: core/forms.py:109
+#: core/forms.py:110
 msgid "Message"
 msgstr "Mensaje"
 
-#: core/forms.py:113
+#: core/forms.py:114 invest/forms.py:96
 msgid "How can we help?"
 msgstr "¿Cómo podemos ayudarle?"
+
+#: core/forms.py:144 core/forms.py:218
+msgid "What market are you in?"
+msgstr ""
 
 #: core/forms.py:175
 msgid ""
@@ -321,15 +329,11 @@ msgstr "Cargo (opcional)"
 msgid "City (Optional)"
 msgstr "Ciudad (opcional)"
 
-#: core/forms.py:218 find_a_supplier/forms.py:269
-msgid "Your country"
-msgstr "Su país"
-
-#: core/forms.py:222
-msgid "Select a country"
+#: core/forms.py:221
+msgid "Select a market"
 msgstr ""
 
-#: core/forms.py:227
+#: core/forms.py:226
 msgid ""
 "Are you interested in buying products or services from UK businesses, either "
 "now or in the near future?"
@@ -337,31 +341,31 @@ msgstr ""
 "¿Está interesado en comprar productos o servicios de empresas del Reino "
 "Unido, ahora o en el futuro cercano?"
 
-#: core/forms.py:236
+#: core/forms.py:235
 msgid "Select either yes or no"
 msgstr ""
 
-#: core/forms.py:241
+#: core/forms.py:240
 msgid "Your industry (optional)"
 msgstr "Su sector (opcional)"
 
-#: core/forms.py:288
+#: core/forms.py:287
 msgid "Expanding to the UK"
 msgstr "Expansión al Reino Unido"
 
-#: core/forms.py:289
+#: core/forms.py:288
 msgid "Investing capital in the UK"
 msgstr "Inversión de capitales en el Reino Unido"
 
-#: core/forms.py:290
+#: core/forms.py:289
 msgid "Exporting to the UK"
 msgstr ""
 
-#: core/forms.py:291
+#: core/forms.py:290
 msgid "Buying from the UK"
 msgstr "Adquisiciones en el Reino Unido"
 
-#: core/forms.py:292
+#: core/forms.py:291
 msgid "The transition period (now that the UK has left the EU)"
 msgstr "Periodo de transición (ahora que el Reino Unido ha salido de la UE)"
 
@@ -584,6 +588,12 @@ msgstr ""
 "Reino Unido, puede suscribirse a continuación. Puede anular la suscripción a "
 "estas actualizaciones en cualquier momento."
 
+#: core/templates/core/includes/form_consent_hpo.html:7
+msgid ""
+"If you would like to receive additional information about expanding to the "
+"UK you can opt in below. You can opt out of these updates at any time."
+msgstr ""
+
 #: core/templates/core/includes/form_consent_invest.html:7
 msgid ""
 "If you would like to receive additional information about investing in the "
@@ -759,23 +769,13 @@ msgid ""
 "\n"
 "              <p>\n"
 "                See our guidance on <a class=\"link\" href="
-"\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
-"transition-period/\">trading with the UK during the transition period and in "
-"2021</a>. If you can’t find the information you’re looking for, complete the "
-"form below and one of our experts will try to help you.\n"
+"\"%(services_urls.international)s/international/content/invest/how-to-setup-"
+"in-the-uk/transition-period/\">trading with the UK during the transition "
+"period and in 2021</a>. If you can’t find the information you’re looking "
+"for, complete the form below and one of our experts will try to help you.\n"
 "              </p>\n"
 "              "
 msgstr ""
-"\n"
-"              <p>\n"
-"                Consulte nuestros consejos en <a class=\"link\" href="
-"\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
-"transition-period/\">comercio con el Reino Unido durante el periodo de "
-"transición y en 2021</a>. Si no encuentra la información que necesita, "
-"rellene el siguiente formulario para que uno de nuestros expertos pueda "
-"ayudarle.\n"
-"              </p>\n"
-"              "
 
 #: find_a_supplier/constants.py:7
 msgid "Magazines, newspaper or trade press"
@@ -809,40 +809,73 @@ msgstr "En un evento"
 msgid "All industries"
 msgstr "Sectores"
 
-#: find_a_supplier/forms.py:169
+#: find_a_supplier/forms.py:172
 msgid "Please select an industry"
 msgstr ""
 
-#: find_a_supplier/forms.py:171
+#: find_a_supplier/forms.py:174
 msgid "Tick the box to confirm you agree to the terms and conditions."
 msgstr ""
 
-#: find_a_supplier/forms.py:178
+#: find_a_supplier/forms.py:181
 msgid "Your name"
 msgstr ""
 
-#: find_a_supplier/forms.py:256
+#: find_a_supplier/forms.py:259
 msgid "Your organisation name"
 msgstr "Nombre de su organización"
 
-#: find_a_supplier/forms.py:264
+#: find_a_supplier/forms.py:267
 msgid "Size of your organisation"
 msgstr "Tamaño de la organización"
 
-#: find_a_supplier/forms.py:274
+#: find_a_supplier/forms.py:272
+msgid "Your country"
+msgstr "Su país"
+
+#: find_a_supplier/forms.py:277
 msgid "Describe what products or services you need"
 msgstr "Describa los productos o servicios que necesita"
 
-#: find_a_supplier/forms.py:275
+#: find_a_supplier/forms.py:278
 msgid "Maximum 1000 characters."
 msgstr "Máximo 1.000 caracteres"
 
-#: find_a_supplier/forms.py:283
+#: find_a_supplier/forms.py:286
 msgid "Where did you hear about great.gov.uk?"
 msgstr "¿Dónde se enteró great.gov.uk?"
 
-#: find_a_supplier/forms.py:292
+#: find_a_supplier/forms.py:295
 msgid "Other source (optional)"
+msgstr ""
+
+#: invest/forms.py:14
+msgid "Advert in a publication"
+msgstr ""
+
+#: invest/forms.py:15
+msgid "Billboard or other outdoor advert"
+msgstr ""
+
+#: invest/forms.py:17
+msgid "Other social media"
+msgstr ""
+
+#: invest/forms.py:25
+msgid "I'm ready to invest and I'd like an adviser to call me."
+msgstr ""
+
+#: invest/forms.py:29
+msgid ""
+"I'm not quite ready to invest but I'd like to get updates on opportunities."
+msgstr ""
+
+#: invest/forms.py:88
+msgid "Which opportunities are you interested in?"
+msgstr ""
+
+#: invest/forms.py:101
+msgid "Tell us about your plans"
 msgstr ""
 
 #: perfect_fit_prospectus/forms.py:12
@@ -899,3 +932,25 @@ msgstr ""
 #, python-format
 msgid "Thank You. Your Perfect Fit Prospectus has been emailed to %(email)s"
 msgstr ""
+
+#~ msgid ""
+#~ "\n"
+#~ "              <p>\n"
+#~ "                See our guidance on <a class=\"link\" href="
+#~ "\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
+#~ "transition-period/\">trading with the UK during the transition period and "
+#~ "in 2021</a>. If you can’t find the information you’re looking for, "
+#~ "complete the form below and one of our experts will try to help you.\n"
+#~ "              </p>\n"
+#~ "              "
+#~ msgstr ""
+#~ "\n"
+#~ "              <p>\n"
+#~ "                Consulte nuestros consejos en <a class=\"link\" href="
+#~ "\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
+#~ "transition-period/\">comercio con el Reino Unido durante el periodo de "
+#~ "transición y en 2021</a>. Si no encuentra la información que necesita, "
+#~ "rellene el siguiente formulario para que uno de nuestros expertos pueda "
+#~ "ayudarle.\n"
+#~ "              </p>\n"
+#~ "              "

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-20 15:48+0000\n"
+"POT-Creation-Date: 2020-08-26 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: contact/forms.py:20 core/forms.py:230
+#: contact/forms.py:20 core/forms.py:229
 msgid "Yes"
 msgstr "Oui"
 
-#: contact/forms.py:21 core/forms.py:231
+#: contact/forms.py:21 core/forms.py:230
 msgid "No"
 msgstr "Non"
 
@@ -34,7 +34,7 @@ msgstr "Publicité dans la presse (journal/revue économique)"
 msgid "Outdoor ad/billboard"
 msgstr "Publicité extérieure/panneau d'affichage"
 
-#: contact/forms.py:26
+#: contact/forms.py:26 invest/forms.py:16
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
@@ -42,11 +42,12 @@ msgstr "LinkedIn"
 msgid "Other social media (e.g. Twitter/Facebook)"
 msgstr "Autres réseaux sociaux (par ex. Twitter/Facebook)"
 
-#: contact/forms.py:28
+#: contact/forms.py:28 invest/forms.py:18
 msgid "Internet search"
 msgstr "Recherche sur Internet"
 
-#: contact/forms.py:29 core/forms.py:293 find_a_supplier/constants.py:38
+#: contact/forms.py:29 core/forms.py:292 find_a_supplier/constants.py:38
+#: invest/forms.py:19
 msgid "Other"
 msgstr "Autre"
 
@@ -87,47 +88,49 @@ msgstr "Le matin"
 msgid "In the afternoon"
 msgstr "L'après-midi"
 
-#: contact/forms.py:76 contact/forms.py:145 core/forms.py:96 core/forms.py:138
-#: core/forms.py:183 euexit/forms.py:50 find_a_supplier/forms.py:224
+#: contact/forms.py:76 contact/forms.py:145 core/forms.py:97 core/forms.py:139
+#: core/forms.py:183 euexit/forms.py:50 find_a_supplier/forms.py:227
+#: invest/forms.py:53
 msgid "Given name"
 msgstr "Prénom"
 
-#: contact/forms.py:77 contact/forms.py:146 core/forms.py:97 core/forms.py:139
-#: core/forms.py:189 euexit/forms.py:51 find_a_supplier/forms.py:232
+#: contact/forms.py:77 contact/forms.py:146 core/forms.py:98 core/forms.py:140
+#: core/forms.py:189 euexit/forms.py:51 find_a_supplier/forms.py:235
+#: invest/forms.py:56
 msgid "Family name"
 msgstr "Nom de famille"
 
-#: contact/forms.py:78 contact/forms.py:147
+#: contact/forms.py:78 contact/forms.py:147 invest/forms.py:59
 msgid "Job title"
 msgstr "Poste"
 
-#: contact/forms.py:79
+#: contact/forms.py:79 invest/forms.py:62
 msgid "Work email address"
 msgstr "E-mail de travail"
 
-#: contact/forms.py:81 contact/forms.py:149 core/forms.py:141
-#: find_a_supplier/forms.py:246
+#: contact/forms.py:81 contact/forms.py:149 core/forms.py:142
+#: find_a_supplier/forms.py:249 invest/forms.py:65
 msgid "Phone number"
 msgstr "Numéro de téléphone"
 
 #: contact/forms.py:83 contact/forms.py:150 core/forms.py:147 core/forms.py:202
-#: euexit/forms.py:58 find_a_supplier/forms.py:187
+#: euexit/forms.py:58 find_a_supplier/forms.py:190 invest/forms.py:68
 msgid "Company name"
 msgstr "Nom de l'entreprise"
 
-#: contact/forms.py:85 contact/forms.py:151
+#: contact/forms.py:85 contact/forms.py:151 invest/forms.py:71
 msgid "Company website"
 msgstr "Site Web de l'entreprise"
 
-#: contact/forms.py:88 contact/forms.py:152
+#: contact/forms.py:88 contact/forms.py:152 invest/forms.py:74
 msgid "Company HQ address"
 msgstr "Adresse du siège social de la société"
 
-#: contact/forms.py:91 core/forms.py:104 euexit/forms.py:60
+#: contact/forms.py:91 core/forms.py:105 euexit/forms.py:60 invest/forms.py:78
 msgid "Which country are you based in?"
 msgstr "Dans quel pays êtes-vous basé ?"
 
-#: contact/forms.py:96 find_a_supplier/forms.py:252
+#: contact/forms.py:96 find_a_supplier/forms.py:255 invest/forms.py:83
 msgid "Your industry"
 msgstr "Votre secteur"
 
@@ -156,20 +159,20 @@ msgstr ""
 msgid "Would you like to arrange a call?"
 msgstr "Voulez-vous planifier un appel ?"
 
-#: contact/forms.py:120 contact/forms.py:159
+#: contact/forms.py:120 contact/forms.py:159 invest/forms.py:105
 msgid "How did you hear about us?"
 msgstr "Où avez-vous entendu parler de nous ?"
 
-#: contact/forms.py:148 core/forms.py:98 core/forms.py:140 core/forms.py:195
-#: euexit/forms.py:52 find_a_supplier/forms.py:179 find_a_supplier/forms.py:240
+#: contact/forms.py:148 core/forms.py:99 core/forms.py:141 core/forms.py:195
+#: euexit/forms.py:52 find_a_supplier/forms.py:182 find_a_supplier/forms.py:243
 msgid "Email address"
 msgstr "E-mail de travail"
 
-#: contact/forms.py:153 core/forms.py:143 perfect_fit_prospectus/forms.py:32
+#: contact/forms.py:153 perfect_fit_prospectus/forms.py:32
 msgid "Country"
 msgstr "Pays"
 
-#: contact/forms.py:154 core/forms.py:149 find_a_supplier/forms.py:181
+#: contact/forms.py:154 core/forms.py:149 find_a_supplier/forms.py:184
 msgid "Industry"
 msgstr ""
 
@@ -208,6 +211,7 @@ msgstr "Votre investissement"
 #: core/templates/core/investment_prospectus_form.html:42
 #: core/templates/core/why_buy_from_the_uk_form.html:54
 #: euexit/templates/euexit/form-contents.html:32
+#: invest/templates/invest/hpo/high_potential_opportunities_form.html:52
 msgid "Submit"
 msgstr "Envoyer"
 
@@ -243,31 +247,31 @@ msgstr "J'aimerais recevoir plus d'informations par e-mail"
 msgid "I would like to receive additional information by telephone"
 msgstr "J'aimerais recevoir plus d'informations par téléphone"
 
-#: core/constants.py:292
+#: core/constants.py:296
 msgid "1-10"
 msgstr ""
 
-#: core/constants.py:293
+#: core/constants.py:297
 msgid "11-50"
 msgstr ""
 
-#: core/constants.py:294
+#: core/constants.py:298
 msgid "51-200"
 msgstr ""
 
-#: core/constants.py:295
+#: core/constants.py:299
 msgid "201-500"
 msgstr ""
 
-#: core/constants.py:296
+#: core/constants.py:300
 msgid "501-1,000"
 msgstr "501-1 000"
 
-#: core/constants.py:297
+#: core/constants.py:301
 msgid "1,001-10,000"
 msgstr "1 001-10 000"
 
-#: core/constants.py:298
+#: core/constants.py:302
 msgid "10,001+"
 msgstr "+ de 10 000"
 
@@ -283,17 +287,21 @@ msgstr "Trouver un fournisseur"
 msgid "Invest"
 msgstr ""
 
-#: core/forms.py:100 core/forms.py:212
+#: core/forms.py:101 core/forms.py:212
 msgid "Phone number (Optional)"
 msgstr "Téléphone de travail"
 
-#: core/forms.py:109
+#: core/forms.py:110
 msgid "Message"
 msgstr "Message"
 
-#: core/forms.py:113
+#: core/forms.py:114 invest/forms.py:96
 msgid "How can we help?"
 msgstr "Comment pouvons-nous aider ?"
+
+#: core/forms.py:144 core/forms.py:218
+msgid "What market are you in?"
+msgstr ""
 
 #: core/forms.py:175
 msgid ""
@@ -323,15 +331,11 @@ msgstr "Poste (facultatif)"
 msgid "City (Optional)"
 msgstr "Ville (facultatif)"
 
-#: core/forms.py:218 find_a_supplier/forms.py:269
-msgid "Your country"
-msgstr "Votre pays"
-
-#: core/forms.py:222
-msgid "Select a country"
+#: core/forms.py:221
+msgid "Select a market"
 msgstr ""
 
-#: core/forms.py:227
+#: core/forms.py:226
 msgid ""
 "Are you interested in buying products or services from UK businesses, either "
 "now or in the near future?"
@@ -339,31 +343,31 @@ msgstr ""
 "Êtes-vous intéressé à acheter des produits ou des services auprès "
 "d'entreprises britanniques, maintenant ou dans un proche avenir?"
 
-#: core/forms.py:236
+#: core/forms.py:235
 msgid "Select either yes or no"
 msgstr ""
 
-#: core/forms.py:241
+#: core/forms.py:240
 msgid "Your industry (optional)"
 msgstr "Votre secteur (facultatif)"
 
-#: core/forms.py:288
+#: core/forms.py:287
 msgid "Expanding to the UK"
 msgstr "Se développer au Royaume-Uni"
 
-#: core/forms.py:289
+#: core/forms.py:288
 msgid "Investing capital in the UK"
 msgstr "Investir des capitaux au Royaume-Uni"
 
-#: core/forms.py:290
+#: core/forms.py:289
 msgid "Exporting to the UK"
 msgstr ""
 
-#: core/forms.py:291
+#: core/forms.py:290
 msgid "Buying from the UK"
 msgstr "Acheter au Royaume-Uni"
 
-#: core/forms.py:292
+#: core/forms.py:291
 msgid "The transition period (now that the UK has left the EU)"
 msgstr "La période de transition (maintenant que le Royaume-Uni a quitté l'UE)"
 
@@ -585,6 +589,12 @@ msgstr ""
 "capitaux au Royaume-Uni, vous pouvez cocher la case ci-dessous. Vous pouvez "
 "vous désabonner de ces mises à jour à tout moment."
 
+#: core/templates/core/includes/form_consent_hpo.html:7
+msgid ""
+"If you would like to receive additional information about expanding to the "
+"UK you can opt in below. You can opt out of these updates at any time."
+msgstr ""
+
 #: core/templates/core/includes/form_consent_invest.html:7
 msgid ""
 "If you would like to receive additional information about investing in the "
@@ -759,23 +769,13 @@ msgid ""
 "\n"
 "              <p>\n"
 "                See our guidance on <a class=\"link\" href="
-"\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
-"transition-period/\">trading with the UK during the transition period and in "
-"2021</a>. If you can’t find the information you’re looking for, complete the "
-"form below and one of our experts will try to help you.\n"
+"\"%(services_urls.international)s/international/content/invest/how-to-setup-"
+"in-the-uk/transition-period/\">trading with the UK during the transition "
+"period and in 2021</a>. If you can’t find the information you’re looking "
+"for, complete the form below and one of our experts will try to help you.\n"
 "              </p>\n"
 "              "
 msgstr ""
-"\n"
-"              <p>\n"
-"                Consultez notre guide sur <a class=\"link\" href="
-"\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
-"transition-period/\">le commerce avec le Royaume-Uni pendant la période de "
-"transition et en 2021</a>. Si vous ne trouvez pas les informations que vous "
-"recherchez, remplissez le formulaire ci-dessous et l'un de nos experts "
-"s'efforcera de vous aider.\n"
-"              </p>\n"
-"              "
 
 #: find_a_supplier/constants.py:7
 msgid "Magazines, newspaper or trade press"
@@ -809,40 +809,73 @@ msgstr "Lors d'un événement"
 msgid "All industries"
 msgstr "Industries"
 
-#: find_a_supplier/forms.py:169
+#: find_a_supplier/forms.py:172
 msgid "Please select an industry"
 msgstr ""
 
-#: find_a_supplier/forms.py:171
+#: find_a_supplier/forms.py:174
 msgid "Tick the box to confirm you agree to the terms and conditions."
 msgstr ""
 
-#: find_a_supplier/forms.py:178
+#: find_a_supplier/forms.py:181
 msgid "Your name"
 msgstr ""
 
-#: find_a_supplier/forms.py:256
+#: find_a_supplier/forms.py:259
 msgid "Your organisation name"
 msgstr "Nom de votre entreprise"
 
-#: find_a_supplier/forms.py:264
+#: find_a_supplier/forms.py:267
 msgid "Size of your organisation"
 msgstr "Taille de votre entreprise"
 
-#: find_a_supplier/forms.py:274
+#: find_a_supplier/forms.py:272
+msgid "Your country"
+msgstr "Votre pays"
+
+#: find_a_supplier/forms.py:277
 msgid "Describe what products or services you need"
 msgstr "Décrivez les produits ou services dont vous avez besoin"
 
-#: find_a_supplier/forms.py:275
+#: find_a_supplier/forms.py:278
 msgid "Maximum 1000 characters."
 msgstr "Maximum 1 000 caractères"
 
-#: find_a_supplier/forms.py:283
+#: find_a_supplier/forms.py:286
 msgid "Where did you hear about great.gov.uk?"
 msgstr "Où avez-vous entendu parler de great.gov.uk ?"
 
-#: find_a_supplier/forms.py:292
+#: find_a_supplier/forms.py:295
 msgid "Other source (optional)"
+msgstr ""
+
+#: invest/forms.py:14
+msgid "Advert in a publication"
+msgstr ""
+
+#: invest/forms.py:15
+msgid "Billboard or other outdoor advert"
+msgstr ""
+
+#: invest/forms.py:17
+msgid "Other social media"
+msgstr ""
+
+#: invest/forms.py:25
+msgid "I'm ready to invest and I'd like an adviser to call me."
+msgstr ""
+
+#: invest/forms.py:29
+msgid ""
+"I'm not quite ready to invest but I'd like to get updates on opportunities."
+msgstr ""
+
+#: invest/forms.py:88
+msgid "Which opportunities are you interested in?"
+msgstr ""
+
+#: invest/forms.py:101
+msgid "Tell us about your plans"
 msgstr ""
 
 #: perfect_fit_prospectus/forms.py:12
@@ -899,3 +932,25 @@ msgstr ""
 #, python-format
 msgid "Thank You. Your Perfect Fit Prospectus has been emailed to %(email)s"
 msgstr ""
+
+#~ msgid ""
+#~ "\n"
+#~ "              <p>\n"
+#~ "                See our guidance on <a class=\"link\" href="
+#~ "\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
+#~ "transition-period/\">trading with the UK during the transition period and "
+#~ "in 2021</a>. If you can’t find the information you’re looking for, "
+#~ "complete the form below and one of our experts will try to help you.\n"
+#~ "              </p>\n"
+#~ "              "
+#~ msgstr ""
+#~ "\n"
+#~ "              <p>\n"
+#~ "                Consultez notre guide sur <a class=\"link\" href="
+#~ "\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
+#~ "transition-period/\">le commerce avec le Royaume-Uni pendant la période "
+#~ "de transition et en 2021</a>. Si vous ne trouvez pas les informations que "
+#~ "vous recherchez, remplissez le formulaire ci-dessous et l'un de nos "
+#~ "experts s'efforcera de vous aider.\n"
+#~ "              </p>\n"
+#~ "              "

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-20 15:48+0000\n"
+"POT-Creation-Date: 2020-08-26 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: contact/forms.py:20 core/forms.py:230
+#: contact/forms.py:20 core/forms.py:229
 msgid "Yes"
 msgstr "はい"
 
-#: contact/forms.py:21 core/forms.py:231
+#: contact/forms.py:21 core/forms.py:230
 msgid "No"
 msgstr "いいえ"
 
@@ -33,7 +33,7 @@ msgstr "出版物の広告（新聞、業界誌）"
 msgid "Outdoor ad/billboard"
 msgstr "屋外広告、看板"
 
-#: contact/forms.py:26
+#: contact/forms.py:26 invest/forms.py:16
 msgid "LinkedIn"
 msgstr ""
 
@@ -41,11 +41,12 @@ msgstr ""
 msgid "Other social media (e.g. Twitter/Facebook)"
 msgstr "その他のソーシャルメディア（例：Twitter、Facebook）"
 
-#: contact/forms.py:28
+#: contact/forms.py:28 invest/forms.py:18
 msgid "Internet search"
 msgstr "インターネット検索"
 
-#: contact/forms.py:29 core/forms.py:293 find_a_supplier/constants.py:38
+#: contact/forms.py:29 core/forms.py:292 find_a_supplier/constants.py:38
+#: invest/forms.py:19
 msgid "Other"
 msgstr "その他"
 
@@ -84,47 +85,49 @@ msgstr "午前"
 msgid "In the afternoon"
 msgstr "午後"
 
-#: contact/forms.py:76 contact/forms.py:145 core/forms.py:96 core/forms.py:138
-#: core/forms.py:183 euexit/forms.py:50 find_a_supplier/forms.py:224
+#: contact/forms.py:76 contact/forms.py:145 core/forms.py:97 core/forms.py:139
+#: core/forms.py:183 euexit/forms.py:50 find_a_supplier/forms.py:227
+#: invest/forms.py:53
 msgid "Given name"
 msgstr "名"
 
-#: contact/forms.py:77 contact/forms.py:146 core/forms.py:97 core/forms.py:139
-#: core/forms.py:189 euexit/forms.py:51 find_a_supplier/forms.py:232
+#: contact/forms.py:77 contact/forms.py:146 core/forms.py:98 core/forms.py:140
+#: core/forms.py:189 euexit/forms.py:51 find_a_supplier/forms.py:235
+#: invest/forms.py:56
 msgid "Family name"
 msgstr "姓"
 
-#: contact/forms.py:78 contact/forms.py:147
+#: contact/forms.py:78 contact/forms.py:147 invest/forms.py:59
 msgid "Job title"
 msgstr "役職"
 
-#: contact/forms.py:79
+#: contact/forms.py:79 invest/forms.py:62
 msgid "Work email address"
 msgstr "メールアドレス"
 
-#: contact/forms.py:81 contact/forms.py:149 core/forms.py:141
-#: find_a_supplier/forms.py:246
+#: contact/forms.py:81 contact/forms.py:149 core/forms.py:142
+#: find_a_supplier/forms.py:249 invest/forms.py:65
 msgid "Phone number"
 msgstr "勤務先の電話番号"
 
 #: contact/forms.py:83 contact/forms.py:150 core/forms.py:147 core/forms.py:202
-#: euexit/forms.py:58 find_a_supplier/forms.py:187
+#: euexit/forms.py:58 find_a_supplier/forms.py:190 invest/forms.py:68
 msgid "Company name"
 msgstr "会社名"
 
-#: contact/forms.py:85 contact/forms.py:151
+#: contact/forms.py:85 contact/forms.py:151 invest/forms.py:71
 msgid "Company website"
 msgstr "企業ウェブサイト"
 
-#: contact/forms.py:88 contact/forms.py:152
+#: contact/forms.py:88 contact/forms.py:152 invest/forms.py:74
 msgid "Company HQ address"
 msgstr "企業の本社所在地"
 
-#: contact/forms.py:91 core/forms.py:104 euexit/forms.py:60
+#: contact/forms.py:91 core/forms.py:105 euexit/forms.py:60 invest/forms.py:78
 msgid "Which country are you based in?"
 msgstr "拠点とされている国はどちらですか？"
 
-#: contact/forms.py:96 find_a_supplier/forms.py:252
+#: contact/forms.py:96 find_a_supplier/forms.py:255 invest/forms.py:83
 msgid "Your industry"
 msgstr "業種"
 
@@ -149,20 +152,20 @@ msgstr ""
 msgid "Would you like to arrange a call?"
 msgstr "電話でのご相談を希望されますか？ "
 
-#: contact/forms.py:120 contact/forms.py:159
+#: contact/forms.py:120 contact/forms.py:159 invest/forms.py:105
 msgid "How did you hear about us?"
 msgstr "国際通商省についてどこでお聞きになりましたか？"
 
-#: contact/forms.py:148 core/forms.py:98 core/forms.py:140 core/forms.py:195
-#: euexit/forms.py:52 find_a_supplier/forms.py:179 find_a_supplier/forms.py:240
+#: contact/forms.py:148 core/forms.py:99 core/forms.py:141 core/forms.py:195
+#: euexit/forms.py:52 find_a_supplier/forms.py:182 find_a_supplier/forms.py:243
 msgid "Email address"
 msgstr "メールアドレス"
 
-#: contact/forms.py:153 core/forms.py:143 perfect_fit_prospectus/forms.py:32
+#: contact/forms.py:153 perfect_fit_prospectus/forms.py:32
 msgid "Country"
 msgstr "国"
 
-#: contact/forms.py:154 core/forms.py:149 find_a_supplier/forms.py:181
+#: contact/forms.py:154 core/forms.py:149 find_a_supplier/forms.py:184
 msgid "Industry"
 msgstr "産業"
 
@@ -201,6 +204,7 @@ msgstr "貴社の投資について"
 #: core/templates/core/investment_prospectus_form.html:42
 #: core/templates/core/why_buy_from_the_uk_form.html:54
 #: euexit/templates/euexit/form-contents.html:32
+#: invest/templates/invest/hpo/high_potential_opportunities_form.html:52
 msgid "Submit"
 msgstr "送信"
 
@@ -234,31 +238,31 @@ msgstr "メールによる追加情報のお知らせを希望"
 msgid "I would like to receive additional information by telephone"
 msgstr "電話による追加情報のお知らせを希望"
 
-#: core/constants.py:292
+#: core/constants.py:296
 msgid "1-10"
 msgstr "1～10 名"
 
-#: core/constants.py:293
+#: core/constants.py:297
 msgid "11-50"
 msgstr "11～50 名"
 
-#: core/constants.py:294
+#: core/constants.py:298
 msgid "51-200"
 msgstr "51～200 名"
 
-#: core/constants.py:295
+#: core/constants.py:299
 msgid "201-500"
 msgstr "201～500 名"
 
-#: core/constants.py:296
+#: core/constants.py:300
 msgid "501-1,000"
 msgstr "501～1,000 名"
 
-#: core/constants.py:297
+#: core/constants.py:301
 msgid "1,001-10,000"
 msgstr "1,001～10,000 名"
 
-#: core/constants.py:298
+#: core/constants.py:302
 msgid "10,001+"
 msgstr "10,001名以上"
 
@@ -274,17 +278,21 @@ msgstr "サプライヤー検索"
 msgid "Invest"
 msgstr ""
 
-#: core/forms.py:100 core/forms.py:212
+#: core/forms.py:101 core/forms.py:212
 msgid "Phone number (Optional)"
 msgstr "勤務先の電話番号"
 
-#: core/forms.py:109
+#: core/forms.py:110
 msgid "Message"
 msgstr "メッセージ"
 
-#: core/forms.py:113
+#: core/forms.py:114 invest/forms.py:96
 msgid "How can we help?"
 msgstr "支援について"
+
+#: core/forms.py:144 core/forms.py:218
+msgid "What market are you in?"
+msgstr ""
 
 #: core/forms.py:175
 msgid ""
@@ -314,15 +322,11 @@ msgstr "役職（任意）"
 msgid "City (Optional)"
 msgstr "都市（任意）"
 
-#: core/forms.py:218 find_a_supplier/forms.py:269
-msgid "Your country"
-msgstr "国名"
-
-#: core/forms.py:222
-msgid "Select a country"
+#: core/forms.py:221
+msgid "Select a market"
 msgstr ""
 
-#: core/forms.py:227
+#: core/forms.py:226
 msgid ""
 "Are you interested in buying products or services from UK businesses, either "
 "now or in the near future?"
@@ -330,31 +334,31 @@ msgstr ""
 "現在または近い将来、英国の企業から製品やサービスを購入することに興味がありま"
 "すか？"
 
-#: core/forms.py:236
+#: core/forms.py:235
 msgid "Select either yes or no"
 msgstr ""
 
-#: core/forms.py:241
+#: core/forms.py:240
 msgid "Your industry (optional)"
 msgstr "業種（任意）"
 
-#: core/forms.py:288
+#: core/forms.py:287
 msgid "Expanding to the UK"
 msgstr "英国への展開"
 
-#: core/forms.py:289
+#: core/forms.py:288
 msgid "Investing capital in the UK"
 msgstr "英国への投資"
 
-#: core/forms.py:290
+#: core/forms.py:289
 msgid "Exporting to the UK"
 msgstr ""
 
-#: core/forms.py:291
+#: core/forms.py:290
 msgid "Buying from the UK"
 msgstr "英国からの輸入"
 
-#: core/forms.py:292
+#: core/forms.py:291
 msgid "The transition period (now that the UK has left the EU)"
 msgstr "移行期間（英国の EU 離脱後）"
 
@@ -570,6 +574,12 @@ msgstr ""
 "英国への展開に関する追加情報をご希望の場合は、以下でご希望の方法をお選びくだ"
 "さい。このお知らせはいつでもオプトアウトできます。"
 
+#: core/templates/core/includes/form_consent_hpo.html:7
+msgid ""
+"If you would like to receive additional information about expanding to the "
+"UK you can opt in below. You can opt out of these updates at any time."
+msgstr ""
+
 #: core/templates/core/includes/form_consent_invest.html:7
 msgid ""
 "If you would like to receive additional information about investing in the "
@@ -732,22 +742,13 @@ msgid ""
 "\n"
 "              <p>\n"
 "                See our guidance on <a class=\"link\" href="
-"\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
-"transition-period/\">trading with the UK during the transition period and in "
-"2021</a>. If you can’t find the information you’re looking for, complete the "
-"form below and one of our experts will try to help you.\n"
+"\"%(services_urls.international)s/international/content/invest/how-to-setup-"
+"in-the-uk/transition-period/\">trading with the UK during the transition "
+"period and in 2021</a>. If you can’t find the information you’re looking "
+"for, complete the form below and one of our experts will try to help you.\n"
 "              </p>\n"
 "              "
 msgstr ""
-"\n"
-"              <p>\n"
-"                <a class=\"link\" href=\"%(services_urls.international)s/"
-"content/invest/how-to-setup-in-the-uk/transition-period/\">移行期間および "
-"2021 年における英国との取引</a>のガイダンスをご参照ください。お探しの情報が見"
-"つからない場合は、次のフォームよりお問い合わせください。国際通商省の専門家が"
-"お手伝いします。\n"
-"              </p>\n"
-"              "
 
 #: find_a_supplier/constants.py:7
 msgid "Magazines, newspaper or trade press"
@@ -781,41 +782,74 @@ msgstr "イベント"
 msgid "All industries"
 msgstr ""
 
-#: find_a_supplier/forms.py:169
+#: find_a_supplier/forms.py:172
 msgid "Please select an industry"
 msgstr ""
 
-#: find_a_supplier/forms.py:171
+#: find_a_supplier/forms.py:174
 msgid "Tick the box to confirm you agree to the terms and conditions."
 msgstr ""
 
-#: find_a_supplier/forms.py:178
+#: find_a_supplier/forms.py:181
 msgid "Your name"
 msgstr ""
 
-#: find_a_supplier/forms.py:256
+#: find_a_supplier/forms.py:259
 msgid "Your organisation name"
 msgstr "社名"
 
-#: find_a_supplier/forms.py:264
+#: find_a_supplier/forms.py:267
 msgid "Size of your organisation"
 msgstr "会社の規模"
 
-#: find_a_supplier/forms.py:274
+#: find_a_supplier/forms.py:272
+msgid "Your country"
+msgstr "国名"
+
+#: find_a_supplier/forms.py:277
 msgid "Describe what products or services you need"
 msgstr "必要な製品やサービスについて教えてください"
 
-#: find_a_supplier/forms.py:275
+#: find_a_supplier/forms.py:278
 msgid "Maximum 1000 characters."
 msgstr "最大 1,000 文字"
 
-#: find_a_supplier/forms.py:283
+#: find_a_supplier/forms.py:286
 msgid "Where did you hear about great.gov.uk?"
 msgstr "great.gov.uk についてどこでお聞きになりましたか？"
 
-#: find_a_supplier/forms.py:292
+#: find_a_supplier/forms.py:295
 msgid "Other source (optional)"
 msgstr "その他"
+
+#: invest/forms.py:14
+msgid "Advert in a publication"
+msgstr ""
+
+#: invest/forms.py:15
+msgid "Billboard or other outdoor advert"
+msgstr ""
+
+#: invest/forms.py:17
+msgid "Other social media"
+msgstr ""
+
+#: invest/forms.py:25
+msgid "I'm ready to invest and I'd like an adviser to call me."
+msgstr ""
+
+#: invest/forms.py:29
+msgid ""
+"I'm not quite ready to invest but I'd like to get updates on opportunities."
+msgstr ""
+
+#: invest/forms.py:88
+msgid "Which opportunities are you interested in?"
+msgstr ""
+
+#: invest/forms.py:101
+msgid "Tell us about your plans"
+msgstr ""
 
 #: perfect_fit_prospectus/forms.py:12
 msgid "Name"
@@ -871,3 +905,24 @@ msgstr ""
 #, python-format
 msgid "Thank You. Your Perfect Fit Prospectus has been emailed to %(email)s"
 msgstr ""
+
+#~ msgid ""
+#~ "\n"
+#~ "              <p>\n"
+#~ "                See our guidance on <a class=\"link\" href="
+#~ "\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
+#~ "transition-period/\">trading with the UK during the transition period and "
+#~ "in 2021</a>. If you can’t find the information you’re looking for, "
+#~ "complete the form below and one of our experts will try to help you.\n"
+#~ "              </p>\n"
+#~ "              "
+#~ msgstr ""
+#~ "\n"
+#~ "              <p>\n"
+#~ "                <a class=\"link\" href=\"%(services_urls.international)s/"
+#~ "content/invest/how-to-setup-in-the-uk/transition-period/\">移行期間および "
+#~ "2021 年における英国との取引</a>のガイダンスをご参照ください。お探しの情報"
+#~ "が見つからない場合は、次のフォームよりお問い合わせください。国際通商省の専"
+#~ "門家がお手伝いします。\n"
+#~ "              </p>\n"
+#~ "              "

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-20 15:48+0000\n"
+"POT-Creation-Date: 2020-08-26 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: contact/forms.py:20 core/forms.py:230
+#: contact/forms.py:20 core/forms.py:229
 msgid "Yes"
 msgstr "Sim"
 
-#: contact/forms.py:21 core/forms.py:231
+#: contact/forms.py:21 core/forms.py:230
 msgid "No"
 msgstr "Não"
 
@@ -34,7 +34,7 @@ msgstr "Anúncio na imprensa (jornal/publicação comercial)"
 msgid "Outdoor ad/billboard"
 msgstr "Anúncio/painel no exterior"
 
-#: contact/forms.py:26
+#: contact/forms.py:26 invest/forms.py:16
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
@@ -42,11 +42,12 @@ msgstr "LinkedIn"
 msgid "Other social media (e.g. Twitter/Facebook)"
 msgstr "Outras redes sociais (por exemplo Twitter/Facebook) "
 
-#: contact/forms.py:28
+#: contact/forms.py:28 invest/forms.py:18
 msgid "Internet search"
 msgstr "Pesquisa na Internet "
 
-#: contact/forms.py:29 core/forms.py:293 find_a_supplier/constants.py:38
+#: contact/forms.py:29 core/forms.py:292 find_a_supplier/constants.py:38
+#: invest/forms.py:19
 msgid "Other"
 msgstr "Outros"
 
@@ -87,47 +88,49 @@ msgstr "De manhã"
 msgid "In the afternoon"
 msgstr "À tarde"
 
-#: contact/forms.py:76 contact/forms.py:145 core/forms.py:96 core/forms.py:138
-#: core/forms.py:183 euexit/forms.py:50 find_a_supplier/forms.py:224
+#: contact/forms.py:76 contact/forms.py:145 core/forms.py:97 core/forms.py:139
+#: core/forms.py:183 euexit/forms.py:50 find_a_supplier/forms.py:227
+#: invest/forms.py:53
 msgid "Given name"
 msgstr "Nome"
 
-#: contact/forms.py:77 contact/forms.py:146 core/forms.py:97 core/forms.py:139
-#: core/forms.py:189 euexit/forms.py:51 find_a_supplier/forms.py:232
+#: contact/forms.py:77 contact/forms.py:146 core/forms.py:98 core/forms.py:140
+#: core/forms.py:189 euexit/forms.py:51 find_a_supplier/forms.py:235
+#: invest/forms.py:56
 msgid "Family name"
 msgstr "Apelido"
 
-#: contact/forms.py:78 contact/forms.py:147
+#: contact/forms.py:78 contact/forms.py:147 invest/forms.py:59
 msgid "Job title"
 msgstr "Cargo"
 
-#: contact/forms.py:79
+#: contact/forms.py:79 invest/forms.py:62
 msgid "Work email address"
 msgstr "E-mail de trabalho"
 
-#: contact/forms.py:81 contact/forms.py:149 core/forms.py:141
-#: find_a_supplier/forms.py:246
+#: contact/forms.py:81 contact/forms.py:149 core/forms.py:142
+#: find_a_supplier/forms.py:249 invest/forms.py:65
 msgid "Phone number"
 msgstr "Número de telefone"
 
 #: contact/forms.py:83 contact/forms.py:150 core/forms.py:147 core/forms.py:202
-#: euexit/forms.py:58 find_a_supplier/forms.py:187
+#: euexit/forms.py:58 find_a_supplier/forms.py:190 invest/forms.py:68
 msgid "Company name"
 msgstr "Nome da empresa"
 
-#: contact/forms.py:85 contact/forms.py:151
+#: contact/forms.py:85 contact/forms.py:151 invest/forms.py:71
 msgid "Company website"
 msgstr "Website da empresa"
 
-#: contact/forms.py:88 contact/forms.py:152
+#: contact/forms.py:88 contact/forms.py:152 invest/forms.py:74
 msgid "Company HQ address"
 msgstr "Endereço da sede da empresa"
 
-#: contact/forms.py:91 core/forms.py:104 euexit/forms.py:60
+#: contact/forms.py:91 core/forms.py:105 euexit/forms.py:60 invest/forms.py:78
 msgid "Which country are you based in?"
 msgstr "Em que país se encontra?"
 
-#: contact/forms.py:96 find_a_supplier/forms.py:252
+#: contact/forms.py:96 find_a_supplier/forms.py:255 invest/forms.py:83
 msgid "Your industry"
 msgstr "A sua indústria"
 
@@ -156,20 +159,20 @@ msgstr ""
 msgid "Would you like to arrange a call?"
 msgstr "Gostaria de agendar uma chamada?"
 
-#: contact/forms.py:120 contact/forms.py:159
+#: contact/forms.py:120 contact/forms.py:159 invest/forms.py:105
 msgid "How did you hear about us?"
 msgstr "Como teve conhecimento sobre nós?"
 
-#: contact/forms.py:148 core/forms.py:98 core/forms.py:140 core/forms.py:195
-#: euexit/forms.py:52 find_a_supplier/forms.py:179 find_a_supplier/forms.py:240
+#: contact/forms.py:148 core/forms.py:99 core/forms.py:141 core/forms.py:195
+#: euexit/forms.py:52 find_a_supplier/forms.py:182 find_a_supplier/forms.py:243
 msgid "Email address"
 msgstr "E-mail de trabalho"
 
-#: contact/forms.py:153 core/forms.py:143 perfect_fit_prospectus/forms.py:32
+#: contact/forms.py:153 perfect_fit_prospectus/forms.py:32
 msgid "Country"
 msgstr "País"
 
-#: contact/forms.py:154 core/forms.py:149 find_a_supplier/forms.py:181
+#: contact/forms.py:154 core/forms.py:149 find_a_supplier/forms.py:184
 msgid "Industry"
 msgstr "Indústria"
 
@@ -208,6 +211,7 @@ msgstr "Seu investimento"
 #: core/templates/core/investment_prospectus_form.html:42
 #: core/templates/core/why_buy_from_the_uk_form.html:54
 #: euexit/templates/euexit/form-contents.html:32
+#: invest/templates/invest/hpo/high_potential_opportunities_form.html:52
 msgid "Submit"
 msgstr "Enviar"
 
@@ -241,31 +245,31 @@ msgstr "Gostaria de receber mais informações por e-mail"
 msgid "I would like to receive additional information by telephone"
 msgstr "Gostaria de receber mais informações por telefone"
 
-#: core/constants.py:292
+#: core/constants.py:296
 msgid "1-10"
 msgstr ""
 
-#: core/constants.py:293
+#: core/constants.py:297
 msgid "11-50"
 msgstr ""
 
-#: core/constants.py:294
+#: core/constants.py:298
 msgid "51-200"
 msgstr ""
 
-#: core/constants.py:295
+#: core/constants.py:299
 msgid "201-500"
 msgstr ""
 
-#: core/constants.py:296
+#: core/constants.py:300
 msgid "501-1,000"
 msgstr "501-1.000"
 
-#: core/constants.py:297
+#: core/constants.py:301
 msgid "1,001-10,000"
 msgstr "1.001-10.000"
 
-#: core/constants.py:298
+#: core/constants.py:302
 msgid "10,001+"
 msgstr "Mais de 10 000"
 
@@ -281,17 +285,21 @@ msgstr "Encontre um fornecedor"
 msgid "Invest"
 msgstr ""
 
-#: core/forms.py:100 core/forms.py:212
+#: core/forms.py:101 core/forms.py:212
 msgid "Phone number (Optional)"
 msgstr "Telefone comercial"
 
-#: core/forms.py:109
+#: core/forms.py:110
 msgid "Message"
 msgstr "Mensagem"
 
-#: core/forms.py:113
+#: core/forms.py:114 invest/forms.py:96
 msgid "How can we help?"
 msgstr "Como podemos ajudar?"
+
+#: core/forms.py:144 core/forms.py:218
+msgid "What market are you in?"
+msgstr ""
 
 #: core/forms.py:175
 msgid ""
@@ -322,15 +330,11 @@ msgstr "Cargo (opcional)"
 msgid "City (Optional)"
 msgstr "Cidade (opcional)"
 
-#: core/forms.py:218 find_a_supplier/forms.py:269
-msgid "Your country"
-msgstr "O seu país"
-
-#: core/forms.py:222
-msgid "Select a country"
+#: core/forms.py:221
+msgid "Select a market"
 msgstr ""
 
-#: core/forms.py:227
+#: core/forms.py:226
 msgid ""
 "Are you interested in buying products or services from UK businesses, either "
 "now or in the near future?"
@@ -338,31 +342,31 @@ msgstr ""
 "Você está interessado em comprar produtos ou serviços de empresas do Reino "
 "Unido, agora ou em um futuro próximo?"
 
-#: core/forms.py:236
+#: core/forms.py:235
 msgid "Select either yes or no"
 msgstr ""
 
-#: core/forms.py:241
+#: core/forms.py:240
 msgid "Your industry (optional)"
 msgstr "A sua indústria (opcional)"
 
-#: core/forms.py:288
+#: core/forms.py:287
 msgid "Expanding to the UK"
 msgstr "Expandir o negócio para o Reino Unido"
 
-#: core/forms.py:289
+#: core/forms.py:288
 msgid "Investing capital in the UK"
 msgstr "Investir capital no Reino Unido"
 
-#: core/forms.py:290
+#: core/forms.py:289
 msgid "Exporting to the UK"
 msgstr ""
 
-#: core/forms.py:291
+#: core/forms.py:290
 msgid "Buying from the UK"
 msgstr "Comprar produtos/serviços do Reino Unido"
 
-#: core/forms.py:292
+#: core/forms.py:291
 msgid "The transition period (now that the UK has left the EU)"
 msgstr "Período de transição (agora que o Reino Unido saiu da UE)"
 
@@ -583,6 +587,12 @@ msgstr ""
 "Reino Unido, pode selecionar esta opção abaixo. Pode optar por não receber "
 "estas atualizações a qualquer momento."
 
+#: core/templates/core/includes/form_consent_hpo.html:7
+msgid ""
+"If you would like to receive additional information about expanding to the "
+"UK you can opt in below. You can opt out of these updates at any time."
+msgstr ""
+
 #: core/templates/core/includes/form_consent_invest.html:7
 msgid ""
 "If you would like to receive additional information about investing in the "
@@ -755,23 +765,13 @@ msgid ""
 "\n"
 "              <p>\n"
 "                See our guidance on <a class=\"link\" href="
-"\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
-"transition-period/\">trading with the UK during the transition period and in "
-"2021</a>. If you can’t find the information you’re looking for, complete the "
-"form below and one of our experts will try to help you.\n"
+"\"%(services_urls.international)s/international/content/invest/how-to-setup-"
+"in-the-uk/transition-period/\">trading with the UK during the transition "
+"period and in 2021</a>. If you can’t find the information you’re looking "
+"for, complete the form below and one of our experts will try to help you.\n"
 "              </p>\n"
 "              "
 msgstr ""
-"\n"
-"              <p>\n"
-"                Consulte as nossas orientações sobre a realização de <a "
-"class=\"link\" href=\"%(services_urls.international)s/content/invest/how-to-"
-"setup-in-the-uk/transition-period/\">negócios com o Reino Unido durante o "
-"período de transição e em 2021</a>. Se não conseguir encontrar as "
-"informações que procura, preencha o formulário abaixo e um dos nossos "
-"especialistas irá tentar ajudá-lo.\n"
-"              </p>\n"
-"              "
 
 #: find_a_supplier/constants.py:7
 msgid "Magazines, newspaper or trade press"
@@ -805,40 +805,73 @@ msgstr "Num evento"
 msgid "All industries"
 msgstr "Indústrias"
 
-#: find_a_supplier/forms.py:169
+#: find_a_supplier/forms.py:172
 msgid "Please select an industry"
 msgstr ""
 
-#: find_a_supplier/forms.py:171
+#: find_a_supplier/forms.py:174
 msgid "Tick the box to confirm you agree to the terms and conditions."
 msgstr ""
 
-#: find_a_supplier/forms.py:178
+#: find_a_supplier/forms.py:181
 msgid "Your name"
 msgstr ""
 
-#: find_a_supplier/forms.py:256
+#: find_a_supplier/forms.py:259
 msgid "Your organisation name"
 msgstr "Nome da sua organização"
 
-#: find_a_supplier/forms.py:264
+#: find_a_supplier/forms.py:267
 msgid "Size of your organisation"
 msgstr "Tamanho da sua organização"
 
-#: find_a_supplier/forms.py:274
+#: find_a_supplier/forms.py:272
+msgid "Your country"
+msgstr "O seu país"
+
+#: find_a_supplier/forms.py:277
 msgid "Describe what products or services you need"
 msgstr "Descreva os produtos ou serviços de que necessita"
 
-#: find_a_supplier/forms.py:275
+#: find_a_supplier/forms.py:278
 msgid "Maximum 1000 characters."
 msgstr "Máximo de 1000 carateres"
 
-#: find_a_supplier/forms.py:283
+#: find_a_supplier/forms.py:286
 msgid "Where did you hear about great.gov.uk?"
 msgstr "Onde teve conhecimento do great.gov.uk?"
 
-#: find_a_supplier/forms.py:292
+#: find_a_supplier/forms.py:295
 msgid "Other source (optional)"
+msgstr ""
+
+#: invest/forms.py:14
+msgid "Advert in a publication"
+msgstr ""
+
+#: invest/forms.py:15
+msgid "Billboard or other outdoor advert"
+msgstr ""
+
+#: invest/forms.py:17
+msgid "Other social media"
+msgstr ""
+
+#: invest/forms.py:25
+msgid "I'm ready to invest and I'd like an adviser to call me."
+msgstr ""
+
+#: invest/forms.py:29
+msgid ""
+"I'm not quite ready to invest but I'd like to get updates on opportunities."
+msgstr ""
+
+#: invest/forms.py:88
+msgid "Which opportunities are you interested in?"
+msgstr ""
+
+#: invest/forms.py:101
+msgid "Tell us about your plans"
 msgstr ""
 
 #: perfect_fit_prospectus/forms.py:12
@@ -895,3 +928,25 @@ msgstr ""
 #, python-format
 msgid "Thank You. Your Perfect Fit Prospectus has been emailed to %(email)s"
 msgstr ""
+
+#~ msgid ""
+#~ "\n"
+#~ "              <p>\n"
+#~ "                See our guidance on <a class=\"link\" href="
+#~ "\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
+#~ "transition-period/\">trading with the UK during the transition period and "
+#~ "in 2021</a>. If you can’t find the information you’re looking for, "
+#~ "complete the form below and one of our experts will try to help you.\n"
+#~ "              </p>\n"
+#~ "              "
+#~ msgstr ""
+#~ "\n"
+#~ "              <p>\n"
+#~ "                Consulte as nossas orientações sobre a realização de <a "
+#~ "class=\"link\" href=\"%(services_urls.international)s/content/invest/how-"
+#~ "to-setup-in-the-uk/transition-period/\">negócios com o Reino Unido "
+#~ "durante o período de transição e em 2021</a>. Se não conseguir encontrar "
+#~ "as informações que procura, preencha o formulário abaixo e um dos nossos "
+#~ "especialistas irá tentar ajudá-lo.\n"
+#~ "              </p>\n"
+#~ "              "

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-20 15:48+0000\n"
+"POT-Creation-Date: 2020-08-26 12:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: contact/forms.py:20 core/forms.py:230
+#: contact/forms.py:20 core/forms.py:229
 msgid "Yes"
 msgstr "是"
 
-#: contact/forms.py:21 core/forms.py:231
+#: contact/forms.py:21 core/forms.py:230
 msgid "No"
 msgstr "否"
 
@@ -33,7 +33,7 @@ msgstr "媒体广告（报纸/行业刊物）"
 msgid "Outdoor ad/billboard"
 msgstr "户外广告/广告牌"
 
-#: contact/forms.py:26
+#: contact/forms.py:26 invest/forms.py:16
 msgid "LinkedIn"
 msgstr ""
 
@@ -41,11 +41,12 @@ msgstr ""
 msgid "Other social media (e.g. Twitter/Facebook)"
 msgstr "其他社交媒体（例如 Twitter/Facebook）"
 
-#: contact/forms.py:28
+#: contact/forms.py:28 invest/forms.py:18
 msgid "Internet search"
 msgstr "互联网搜索"
 
-#: contact/forms.py:29 core/forms.py:293 find_a_supplier/constants.py:38
+#: contact/forms.py:29 core/forms.py:292 find_a_supplier/constants.py:38
+#: invest/forms.py:19
 msgid "Other"
 msgstr "其他"
 
@@ -81,47 +82,49 @@ msgstr "上午"
 msgid "In the afternoon"
 msgstr "下午"
 
-#: contact/forms.py:76 contact/forms.py:145 core/forms.py:96 core/forms.py:138
-#: core/forms.py:183 euexit/forms.py:50 find_a_supplier/forms.py:224
+#: contact/forms.py:76 contact/forms.py:145 core/forms.py:97 core/forms.py:139
+#: core/forms.py:183 euexit/forms.py:50 find_a_supplier/forms.py:227
+#: invest/forms.py:53
 msgid "Given name"
 msgstr "名字"
 
-#: contact/forms.py:77 contact/forms.py:146 core/forms.py:97 core/forms.py:139
-#: core/forms.py:189 euexit/forms.py:51 find_a_supplier/forms.py:232
+#: contact/forms.py:77 contact/forms.py:146 core/forms.py:98 core/forms.py:140
+#: core/forms.py:189 euexit/forms.py:51 find_a_supplier/forms.py:235
+#: invest/forms.py:56
 msgid "Family name"
 msgstr "姓"
 
-#: contact/forms.py:78 contact/forms.py:147
+#: contact/forms.py:78 contact/forms.py:147 invest/forms.py:59
 msgid "Job title"
 msgstr "职务（可选）"
 
-#: contact/forms.py:79
+#: contact/forms.py:79 invest/forms.py:62
 msgid "Work email address"
 msgstr "电子邮件地址"
 
-#: contact/forms.py:81 contact/forms.py:149 core/forms.py:141
-#: find_a_supplier/forms.py:246
+#: contact/forms.py:81 contact/forms.py:149 core/forms.py:142
+#: find_a_supplier/forms.py:249 invest/forms.py:65
 msgid "Phone number"
 msgstr "电话号码"
 
 #: contact/forms.py:83 contact/forms.py:150 core/forms.py:147 core/forms.py:202
-#: euexit/forms.py:58 find_a_supplier/forms.py:187
+#: euexit/forms.py:58 find_a_supplier/forms.py:190 invest/forms.py:68
 msgid "Company name"
 msgstr "公司名称"
 
-#: contact/forms.py:85 contact/forms.py:151
+#: contact/forms.py:85 contact/forms.py:151 invest/forms.py:71
 msgid "Company website"
 msgstr "公司网站"
 
-#: contact/forms.py:88 contact/forms.py:152
+#: contact/forms.py:88 contact/forms.py:152 invest/forms.py:74
 msgid "Company HQ address"
 msgstr "公司总部地址"
 
-#: contact/forms.py:91 core/forms.py:104 euexit/forms.py:60
+#: contact/forms.py:91 core/forms.py:105 euexit/forms.py:60 invest/forms.py:78
 msgid "Which country are you based in?"
 msgstr "您所在的国家/地区？"
 
-#: contact/forms.py:96 find_a_supplier/forms.py:252
+#: contact/forms.py:96 find_a_supplier/forms.py:255 invest/forms.py:83
 msgid "Your industry"
 msgstr "您的行业"
 
@@ -146,20 +149,20 @@ msgstr ""
 msgid "Would you like to arrange a call?"
 msgstr "您是否希望安排通话？"
 
-#: contact/forms.py:120 contact/forms.py:159
+#: contact/forms.py:120 contact/forms.py:159 invest/forms.py:105
 msgid "How did you hear about us?"
 msgstr "您是通过哪种渠道了解到我们的？"
 
-#: contact/forms.py:148 core/forms.py:98 core/forms.py:140 core/forms.py:195
-#: euexit/forms.py:52 find_a_supplier/forms.py:179 find_a_supplier/forms.py:240
+#: contact/forms.py:148 core/forms.py:99 core/forms.py:141 core/forms.py:195
+#: euexit/forms.py:52 find_a_supplier/forms.py:182 find_a_supplier/forms.py:243
 msgid "Email address"
 msgstr "电子邮件地址"
 
-#: contact/forms.py:153 core/forms.py:143 perfect_fit_prospectus/forms.py:32
+#: contact/forms.py:153 perfect_fit_prospectus/forms.py:32
 msgid "Country"
 msgstr "国家"
 
-#: contact/forms.py:154 core/forms.py:149 find_a_supplier/forms.py:181
+#: contact/forms.py:154 core/forms.py:149 find_a_supplier/forms.py:184
 msgid "Industry"
 msgstr "行业"
 
@@ -198,6 +201,7 @@ msgstr "您的投资"
 #: core/templates/core/investment_prospectus_form.html:42
 #: core/templates/core/why_buy_from_the_uk_form.html:54
 #: euexit/templates/euexit/form-contents.html:32
+#: invest/templates/invest/hpo/high_potential_opportunities_form.html:52
 msgid "Submit"
 msgstr "提交"
 
@@ -229,31 +233,31 @@ msgstr "我想通过电子邮件收到更多信息"
 msgid "I would like to receive additional information by telephone"
 msgstr "我想通过电话收到更多信息"
 
-#: core/constants.py:292
+#: core/constants.py:296
 msgid "1-10"
 msgstr "1-10 人"
 
-#: core/constants.py:293
+#: core/constants.py:297
 msgid "11-50"
 msgstr "11-50 人"
 
-#: core/constants.py:294
+#: core/constants.py:298
 msgid "51-200"
 msgstr "51-200 人"
 
-#: core/constants.py:295
+#: core/constants.py:299
 msgid "201-500"
 msgstr "201-500 人"
 
-#: core/constants.py:296
+#: core/constants.py:300
 msgid "501-1,000"
 msgstr "501-1,000 人"
 
-#: core/constants.py:297
+#: core/constants.py:301
 msgid "1,001-10,000"
 msgstr "1,001-10,000 人"
 
-#: core/constants.py:298
+#: core/constants.py:302
 msgid "10,001+"
 msgstr "10,000 人以上"
 
@@ -269,17 +273,21 @@ msgstr "供应商信息"
 msgid "Invest"
 msgstr ""
 
-#: core/forms.py:100 core/forms.py:212
+#: core/forms.py:101 core/forms.py:212
 msgid "Phone number (Optional)"
 msgstr "电话号码（可选）"
 
-#: core/forms.py:109
+#: core/forms.py:110
 msgid "Message"
 msgstr "消息"
 
-#: core/forms.py:113
+#: core/forms.py:114 invest/forms.py:96
 msgid "How can we help?"
 msgstr "我们如何提供帮助？"
+
+#: core/forms.py:144 core/forms.py:218
+msgid "What market are you in?"
+msgstr ""
 
 #: core/forms.py:175
 msgid ""
@@ -309,45 +317,41 @@ msgstr "职务（可选）"
 msgid "City (Optional)"
 msgstr "城市（可选）"
 
-#: core/forms.py:218 find_a_supplier/forms.py:269
-msgid "Your country"
-msgstr "您所在的国家/地区"
-
-#: core/forms.py:222
-msgid "Select a country"
+#: core/forms.py:221
+msgid "Select a market"
 msgstr ""
 
-#: core/forms.py:227
+#: core/forms.py:226
 msgid ""
 "Are you interested in buying products or services from UK businesses, either "
 "now or in the near future?"
 msgstr "您是否对现在或不久的将来从英国企业购买产品或服务感兴趣？"
 
-#: core/forms.py:236
+#: core/forms.py:235
 msgid "Select either yes or no"
 msgstr ""
 
-#: core/forms.py:241
+#: core/forms.py:240
 msgid "Your industry (optional)"
 msgstr "您的行业（可选）"
 
-#: core/forms.py:288
+#: core/forms.py:287
 msgid "Expanding to the UK"
 msgstr "登陆英国市场"
 
-#: core/forms.py:289
+#: core/forms.py:288
 msgid "Investing capital in the UK"
 msgstr "投资英国资本市场"
 
-#: core/forms.py:290
+#: core/forms.py:289
 msgid "Exporting to the UK"
 msgstr ""
 
-#: core/forms.py:291
+#: core/forms.py:290
 msgid "Buying from the UK"
 msgstr "从英国采购"
 
-#: core/forms.py:292
+#: core/forms.py:291
 msgid "The transition period (now that the UK has left the EU)"
 msgstr "过渡期（英国已脱欧）"
 
@@ -561,6 +565,12 @@ msgstr ""
 "如果您想收到更多关于投资英国资本市场的信息，那么可以在下方选择加入。您可以随"
 "时选择取消接收更新。"
 
+#: core/templates/core/includes/form_consent_hpo.html:7
+msgid ""
+"If you would like to receive additional information about expanding to the "
+"UK you can opt in below. You can opt out of these updates at any time."
+msgstr ""
+
 #: core/templates/core/includes/form_consent_invest.html:7
 msgid ""
 "If you would like to receive additional information about investing in the "
@@ -717,21 +727,13 @@ msgid ""
 "\n"
 "              <p>\n"
 "                See our guidance on <a class=\"link\" href="
-"\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
-"transition-period/\">trading with the UK during the transition period and in "
-"2021</a>. If you can’t find the information you’re looking for, complete the "
-"form below and one of our experts will try to help you.\n"
+"\"%(services_urls.international)s/international/content/invest/how-to-setup-"
+"in-the-uk/transition-period/\">trading with the UK during the transition "
+"period and in 2021</a>. If you can’t find the information you’re looking "
+"for, complete the form below and one of our experts will try to help you.\n"
 "              </p>\n"
 "              "
 msgstr ""
-"\n"
-"              <p>\n"
-"                查看<a class=\"link\" href=\"%(services_urls.international)s/"
-"content/invest/how-to-setup-in-the-uk/transition-period/\">过渡期及 2021 年英"
-"国贸易往来</a>指南。如果找不到需要的信息，请填写下面的表格，我们的专家将为您"
-"提供帮助。\n"
-"              </p>\n"
-"              "
 
 #: find_a_supplier/constants.py:7
 msgid "Magazines, newspaper or trade press"
@@ -765,40 +767,73 @@ msgstr "特定活动"
 msgid "All industries"
 msgstr "行业"
 
-#: find_a_supplier/forms.py:169
+#: find_a_supplier/forms.py:172
 msgid "Please select an industry"
 msgstr ""
 
-#: find_a_supplier/forms.py:171
+#: find_a_supplier/forms.py:174
 msgid "Tick the box to confirm you agree to the terms and conditions."
 msgstr ""
 
-#: find_a_supplier/forms.py:178
+#: find_a_supplier/forms.py:181
 msgid "Your name"
 msgstr ""
 
-#: find_a_supplier/forms.py:256
+#: find_a_supplier/forms.py:259
 msgid "Your organisation name"
 msgstr "您的组织名称"
 
-#: find_a_supplier/forms.py:264
+#: find_a_supplier/forms.py:267
 msgid "Size of your organisation"
 msgstr "您的组织规模"
 
-#: find_a_supplier/forms.py:274
+#: find_a_supplier/forms.py:272
+msgid "Your country"
+msgstr "您所在的国家/地区"
+
+#: find_a_supplier/forms.py:277
 msgid "Describe what products or services you need"
 msgstr "描述您需要哪些产品或服务"
 
-#: find_a_supplier/forms.py:275
+#: find_a_supplier/forms.py:278
 msgid "Maximum 1000 characters."
 msgstr "最多 1,000 个字符"
 
-#: find_a_supplier/forms.py:283
+#: find_a_supplier/forms.py:286
 msgid "Where did you hear about great.gov.uk?"
 msgstr "您从哪里了解到 great.gov.uk？"
 
-#: find_a_supplier/forms.py:292
+#: find_a_supplier/forms.py:295
 msgid "Other source (optional)"
+msgstr ""
+
+#: invest/forms.py:14
+msgid "Advert in a publication"
+msgstr ""
+
+#: invest/forms.py:15
+msgid "Billboard or other outdoor advert"
+msgstr ""
+
+#: invest/forms.py:17
+msgid "Other social media"
+msgstr ""
+
+#: invest/forms.py:25
+msgid "I'm ready to invest and I'd like an adviser to call me."
+msgstr ""
+
+#: invest/forms.py:29
+msgid ""
+"I'm not quite ready to invest but I'd like to get updates on opportunities."
+msgstr ""
+
+#: invest/forms.py:88
+msgid "Which opportunities are you interested in?"
+msgstr ""
+
+#: invest/forms.py:101
+msgid "Tell us about your plans"
 msgstr ""
 
 #: perfect_fit_prospectus/forms.py:12
@@ -855,3 +890,23 @@ msgstr ""
 #, python-format
 msgid "Thank You. Your Perfect Fit Prospectus has been emailed to %(email)s"
 msgstr ""
+
+#~ msgid ""
+#~ "\n"
+#~ "              <p>\n"
+#~ "                See our guidance on <a class=\"link\" href="
+#~ "\"%(services_urls.international)s/content/invest/how-to-setup-in-the-uk/"
+#~ "transition-period/\">trading with the UK during the transition period and "
+#~ "in 2021</a>. If you can’t find the information you’re looking for, "
+#~ "complete the form below and one of our experts will try to help you.\n"
+#~ "              </p>\n"
+#~ "              "
+#~ msgstr ""
+#~ "\n"
+#~ "              <p>\n"
+#~ "                查看<a class=\"link\" href=\"%(services_urls."
+#~ "international)s/content/invest/how-to-setup-in-the-uk/transition-period/"
+#~ "\">过渡期及 2021 年英国贸易往来</a>指南。如果找不到需要的信息，请填写下面"
+#~ "的表格，我们的专家将为您提供帮助。\n"
+#~ "              </p>\n"
+#~ "              "


### PR DESCRIPTION
Update the two forms below to replace country with market backed by the countries and territories list.

- BusinessEnvironmentGuideForm
- WhyBuyFromUKForm

------------------

### BusinessEnvironmentGuideForm

#### Before
![business-environment-guide-before](https://user-images.githubusercontent.com/594496/91323659-0bbb1f00-e7b9-11ea-9bac-6d53f9bd8865.png)


#### After
![business-environment-guide-after](https://user-images.githubusercontent.com/594496/91323052-58522a80-e7b8-11ea-8823-cdabcfcf9445.png)

------------------

### WhyBuyFromUKForm

#### Before
![why-buy-from-the-uk-before](https://user-images.githubusercontent.com/594496/91323545-e75f4280-e7b8-11ea-9507-7bf4814f3b1e.png)

#### After
![why-buy-from-the-uk-after](https://user-images.githubusercontent.com/594496/91323054-58eac100-e7b8-11ea-8119-3fe3c5c059f0.png)

-------------

To do (delete all that do not apply):

 - [x] Changelog entry added.
 - [x] (if changing content) Locale files have been updated and translated strings have been added if available.
 - [x] (if changing the UI) Add a printscreen to the PR
