### PR TITLE
GBAU-918 Fix reCaptcha timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Pre-release
 ### Fixed bugs
+- GBAU-918 Fix reCaptcha token timeout
 
 ## [1.0.2](https://github.com/uktrade/great-international-ui/releases/tag/1.0.2)
 [Full Changelog](https://github.com/uktrade/great-international-ui/compare/1.0.1...1.0.2)

--- a/core/templates/captcha/includes/js_v3.html
+++ b/core/templates/captcha/includes/js_v3.html
@@ -1,0 +1,17 @@
+<script src="https://{{ recaptcha_domain }}/recaptcha/api.js?render={{ public_key }}{% if api_params %}&{{ api_params }}{% endif %}"></script>
+<script>
+  // attach reCapture check on form submit to stop token expiry.
+  grecaptcha.ready(function() {
+    const form = document.querySelector("main form")
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      grecaptcha.execute('{{ public_key }}', {action: 'form'})
+        .then(function(token) {
+          console.log("reCAPTCHA validated for 'data-widget-uuid=\"{{ widget_uuid }}\"'. Setting input value...")
+          var element = document.querySelector('.g-recaptcha[data-widget-uuid="{{ widget_uuid }}"]');
+          element.value = token;
+          form.submit();
+        });
+    });
+  });
+</script>


### PR DESCRIPTION
Change captcha implementation so that the challenge token is created only as the form is submitted rather than on load. This removes the potential for the token to expire before submission.

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.

