### PR TITLE
NOTICKET: Upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Implemented enhancements
  
- - GBAU-950 - update content on  Investment Support Directory home page
+ - NOTICKET - django upgrade
+ - GBAU-950 - update content on Investment Support Directory home page
 ### Fixed bugs
 
 ## [2.0.0](https://github.com/uktrade/great-international-ui/releases/tag/2.0.0)

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ django-ipware==2.1.0
 django-recaptcha==2.0.5
 django-redis==4.10.0
 django-storages==1.7.2
-Django==2.2.20
+Django==2.2.21
 djangorestframework==3.11.2
 elastic-apm>=5.5.2,<6.0.0
 pir-client==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,182 +4,68 @@
 #
 #    pip-compile requirements.in
 #
-attrs==19.1.0
-    # via jsonschema
-beautifulsoup4==4.8.0
-    # via directory-components
-boto3==1.9.232
-    # via -r requirements.in
-botocore==1.12.232
-    # via
-    #   boto3
-    #   s3transfer
-certifi==2019.9.11
-    # via
-    #   elastic-apm
-    #   requests
-    #   sentry-sdk
-cffi==1.13.2
-    # via cryptography
-chardet==3.0.4
-    # via requests
-cryptography==3.3.2
-    # via
-    #   pyopenssl
-    #   requests
-dateparser==0.7.0
-    # via -r requirements.in
-directory-api-client==20.0.0
-    # via -r requirements.in
-directory-client-core==6.1.0
-    # via
-    #   directory-api-client
-    #   directory-cms-client
-    #   directory-forms-api-client
-    #   pir-client
-directory-cms-client==10.2.0
-    # via -r requirements.in
-directory-components==35.26.0
-    # via -r requirements.in
-directory-constants==20.11.0
-    # via
-    #   -r requirements.in
-    #   directory-components
-directory-forms-api-client==5.1.0
-    # via -r requirements.in
-directory-healthcheck==2.0.0
-    # via -r requirements.in
-directory-validators==6.0.5
-    # via -r requirements.in
-django-countries==5.5
-    # via -r requirements.in
-django-environ==0.4.5
-    # via -r requirements.in
-django-formtools==2.1
-    # via -r requirements.in
-django-health-check==3.8.0
-    # via directory-healthcheck
-django-ipware==2.1.0
-    # via -r requirements.in
-django-recaptcha==2.0.5
-    # via -r requirements.in
-django-redis==4.10.0
-    # via -r requirements.in
-django-storages==1.7.2
-    # via -r requirements.in
-django==2.2.20
-    # via
-    #   -r requirements.in
-    #   directory-api-client
-    #   directory-client-core
-    #   directory-components
-    #   directory-constants
-    #   directory-healthcheck
-    #   directory-validators
-    #   django-formtools
-    #   django-recaptcha
-    #   django-redis
-    #   django-storages
-    #   djangorestframework
-    #   sigauth
-djangorestframework==3.11.2
-    # via
-    #   -r requirements.in
-    #   sigauth
-docutils==0.15.2
-    # via botocore
-elastic-apm==5.5.2
-    # via -r requirements.in
-gevent==1.5a3
-    # via -r requirements.in
-greenlet==0.4.16
-    # via gevent
-gunicorn==20.0.4
-    # via -r requirements.in
-idna==2.8
-    # via requests
-jmespath==0.9.4
-    # via
-    #   boto3
-    #   botocore
-jsonschema==3.0.2
-    # via directory-components
-mohawk==0.3.4
-    # via sigauth
-monotonic==1.5
-    # via directory-client-core
-olefile==0.44
-    # via directory-validators
-pillow==8.1.2
-    # via directory-validators
-pir-client==1.1.0
-    # via -r requirements.in
-psycogreen==1.0.2
-    # via -r requirements.in
-psycopg2==2.8.5
-    # via -r requirements.in
-pycparser==2.19
-    # via cffi
-pyopenssl==19.1.0
-    # via requests
-pyrsistent==0.15.4
-    # via jsonschema
-python-dateutil==2.8.0
-    # via
-    #   botocore
-    #   dateparser
-pytz==2017.2
-    # via
-    #   dateparser
-    #   directory-validators
-    #   django
-    #   tzlocal
-redis==3.3.8
-    # via django-redis
-regex==2019.8.19
-    # via dateparser
-requests[security]==2.22.0
-    # via
-    #   -r requirements.in
-    #   directory-api-client
-    #   directory-client-core
-s3transfer==0.2.1
-    # via boto3
-sentry-sdk==0.13.4
-    # via -r requirements.in
-sigauth==4.1.1
-    # via directory-client-core
-six==1.12.0
-    # via
-    #   cryptography
-    #   django-countries
-    #   jsonschema
-    #   pyopenssl
-    #   pyrsistent
-    #   python-dateutil
-    #   w3lib
-sorl-thumbnail==12.5.0
-    # via -r requirements.in
-soupsieve==1.9.3
-    # via beautifulsoup4
-sqlparse==0.3.0
-    # via django
-tzlocal==2.0.0
-    # via dateparser
-urllib3==1.24.3
-    # via
-    #   -r requirements.in
-    #   botocore
-    #   directory-validators
-    #   elastic-apm
-    #   requests
-    #   sentry-sdk
-w3lib==1.21.0
-    # via directory-client-core
-waitress==1.4.3
-    # via -r requirements.in
-whitenoise==4.1.3
-    # via -r requirements.in
+attrs==19.1.0             # via jsonschema
+beautifulsoup4==4.8.0     # via directory-components
+boto3==1.9.232            # via -r requirements.in
+botocore==1.12.232        # via boto3, s3transfer
+certifi==2019.9.11        # via elastic-apm, requests, sentry-sdk
+cffi==1.13.2              # via cryptography
+chardet==3.0.4            # via requests
+cryptography==3.3.2       # via pyopenssl, requests
+dateparser==0.7.0         # via -r requirements.in
+directory-api-client==20.0.0  # via -r requirements.in
+directory-client-core==6.1.0  # via directory-api-client, directory-cms-client, directory-forms-api-client, pir-client
+directory-cms-client==10.2.0  # via -r requirements.in
+directory-components==35.26.0  # via -r requirements.in
+directory-constants==20.11.0  # via -r requirements.in, directory-components
+directory-forms-api-client==5.1.0  # via -r requirements.in
+directory-healthcheck==2.0.0  # via -r requirements.in
+directory-validators==6.0.5  # via -r requirements.in
+django-countries==5.5     # via -r requirements.in
+django-environ==0.4.5     # via -r requirements.in
+django-formtools==2.1     # via -r requirements.in
+django-health-check==3.8.0  # via directory-healthcheck
+django-ipware==2.1.0      # via -r requirements.in
+django-recaptcha==2.0.5   # via -r requirements.in
+django-redis==4.10.0      # via -r requirements.in
+django-storages==1.7.2    # via -r requirements.in
+django==2.2.21            # via -r requirements.in, directory-api-client, directory-client-core, directory-components, directory-constants, directory-healthcheck, directory-validators, django-formtools, django-recaptcha, django-redis, django-storages, djangorestframework, sigauth
+djangorestframework==3.11.2  # via -r requirements.in, sigauth
+docutils==0.15.2          # via botocore
+elastic-apm==5.5.2        # via -r requirements.in
+gevent==1.5a3             # via -r requirements.in
+greenlet==0.4.16          # via gevent
+gunicorn==20.0.4          # via -r requirements.in
+idna==2.8                 # via requests
+jmespath==0.9.4           # via boto3, botocore
+jsonschema==3.0.2         # via directory-components
+mohawk==0.3.4             # via sigauth
+monotonic==1.5            # via directory-client-core
+olefile==0.44             # via directory-validators
+pillow==8.1.2             # via directory-validators
+pir-client==1.1.0         # via -r requirements.in
+psycogreen==1.0.2         # via -r requirements.in
+psycopg2==2.8.5           # via -r requirements.in
+pycparser==2.19           # via cffi
+pyopenssl==19.1.0         # via requests
+pyrsistent==0.15.4        # via jsonschema
+python-dateutil==2.8.0    # via botocore, dateparser
+pytz==2017.2              # via dateparser, directory-validators, django, tzlocal
+redis==3.3.8              # via django-redis
+regex==2019.8.19          # via dateparser
+requests[security]==2.22.0  # via -r requirements.in, directory-api-client, directory-client-core
+s3transfer==0.2.1         # via boto3
+sentry-sdk==0.13.4        # via -r requirements.in
+sigauth==4.1.1            # via directory-client-core
+six==1.12.0               # via cryptography, django-countries, jsonschema, pyopenssl, pyrsistent, python-dateutil, w3lib
+sorl-thumbnail==12.5.0    # via -r requirements.in
+soupsieve==1.9.3          # via beautifulsoup4
+sqlparse==0.3.0           # via django
+tzlocal==2.0.0            # via dateparser
+urllib3==1.24.3           # via -r requirements.in, botocore, directory-validators, elastic-apm, requests, sentry-sdk
+w3lib==1.21.0             # via directory-client-core
+waitress==1.4.3           # via -r requirements.in
+whitenoise==4.1.3         # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements_test.in
+++ b/requirements_test.in
@@ -10,4 +10,4 @@ flake8
 requests_mock
 freezegun
 codecov==2.1.9
-
+py>=1.10.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,264 +4,97 @@
 #
 #    pip-compile requirements_test.in
 #
-apipkg==1.5
-    # via execnet
-atomicwrites==1.3.0
-    # via pytest
-attrs==19.1.0
-    # via
-    #   jsonschema
-    #   pytest
-beautifulsoup4==4.8.0
-    # via directory-components
-boto3==1.9.232
-    # via -r requirements.in
-botocore==1.12.232
-    # via
-    #   boto3
-    #   s3transfer
-certifi==2019.9.11
-    # via
-    #   elastic-apm
-    #   requests
-    #   sentry-sdk
-cffi==1.13.2
-    # via cryptography
-chardet==3.0.4
-    # via requests
-click==7.0
-    # via pip-tools
-codecov==2.1.9
-    # via -r requirements_test.in
-coverage==4.5.4
-    # via
-    #   codecov
-    #   pytest-cov
-cryptography==3.3.2
-    # via
-    #   pyopenssl
-    #   requests
-dateparser==0.7.0
-    # via -r requirements.in
-directory-api-client==20.0.0
-    # via -r requirements.in
-directory-client-core==6.1.0
-    # via
-    #   directory-api-client
-    #   directory-cms-client
-    #   directory-forms-api-client
-    #   pir-client
-directory-cms-client==10.2.0
-    # via -r requirements.in
-directory-components==35.26.0
-    # via -r requirements.in
-directory-constants==20.11.0
-    # via
-    #   -r requirements.in
-    #   directory-components
-directory-forms-api-client==5.1.0
-    # via -r requirements.in
-directory-healthcheck==2.0.0
-    # via -r requirements.in
-directory-validators==6.0.5
-    # via -r requirements.in
-django-countries==5.5
-    # via -r requirements.in
-django-environ==0.4.5
-    # via -r requirements.in
-django-formtools==2.1
-    # via -r requirements.in
-django-health-check==3.8.0
-    # via directory-healthcheck
-django-ipware==2.1.0
-    # via -r requirements.in
-django-recaptcha==2.0.5
-    # via -r requirements.in
-django-redis==4.10.0
-    # via -r requirements.in
-django-storages==1.7.2
-    # via -r requirements.in
-django==2.2.20
-    # via
-    #   -r requirements.in
-    #   directory-api-client
-    #   directory-client-core
-    #   directory-components
-    #   directory-constants
-    #   directory-healthcheck
-    #   directory-validators
-    #   django-formtools
-    #   django-recaptcha
-    #   django-redis
-    #   django-storages
-    #   djangorestframework
-    #   sigauth
-djangorestframework==3.11.2
-    # via
-    #   -r requirements.in
-    #   sigauth
-docutils==0.15.2
-    # via botocore
-elastic-apm==5.5.2
-    # via -r requirements.in
-entrypoints==0.3
-    # via flake8
-execnet==1.7.1
-    # via pytest-xdist
-flake8==3.7.8
-    # via -r requirements_test.in
-freezegun==0.3.12
-    # via -r requirements_test.in
-gevent==1.5a3
-    # via -r requirements.in
-greenlet==0.4.16
-    # via gevent
-gunicorn==20.0.4
-    # via -r requirements.in
-idna==2.8
-    # via requests
-importlib-metadata==0.23
-    # via
-    #   pluggy
-    #   pytest
-jmespath==0.9.4
-    # via
-    #   boto3
-    #   botocore
-jsonschema==3.0.2
-    # via directory-components
-mccabe==0.6.1
-    # via flake8
-mohawk==0.3.4
-    # via sigauth
-monotonic==1.5
-    # via directory-client-core
-more-itertools==7.2.0
-    # via
-    #   pytest
-    #   zipp
-olefile==0.44
-    # via directory-validators
-packaging==19.2
-    # via
-    #   pytest
-    #   pytest-sugar
-pillow==8.1.2
-    # via directory-validators
-pip-tools==5.3.0
-    # via -r requirements_test.in
-pir-client==1.1.0
-    # via -r requirements.in
-pluggy==0.13.0
-    # via pytest
-psycogreen==1.0.2
-    # via -r requirements.in
-psycopg2==2.8.5
-    # via -r requirements.in
-py==1.8.0
-    # via pytest
-pycodestyle==2.5.0
-    # via flake8
-pycparser==2.19
-    # via cffi
-pyflakes==2.1.1
-    # via flake8
-pyopenssl==19.1.0
-    # via requests
-pyparsing==2.4.2
-    # via packaging
-pyrsistent==0.15.4
-    # via jsonschema
-pytest-cov==2.7.1
-    # via -r requirements_test.in
-pytest-django==3.5.1
-    # via -r requirements_test.in
-pytest-forked==1.0.2
-    # via pytest-xdist
-pytest-sugar==0.9.2
-    # via -r requirements_test.in
-pytest-xdist==1.29.0
-    # via -r requirements_test.in
-pytest==5.1.2
-    # via
-    #   -r requirements_test.in
-    #   pytest-cov
-    #   pytest-django
-    #   pytest-forked
-    #   pytest-sugar
-    #   pytest-xdist
-python-dateutil==2.8.0
-    # via
-    #   botocore
-    #   dateparser
-    #   freezegun
-pytz==2017.2
-    # via
-    #   dateparser
-    #   directory-validators
-    #   django
-    #   tzlocal
-redis==3.3.8
-    # via django-redis
-regex==2019.8.19
-    # via dateparser
-requests-mock==1.7.0
-    # via -r requirements_test.in
-requests[security]==2.22.0
-    # via
-    #   -r requirements.in
-    #   codecov
-    #   directory-api-client
-    #   directory-client-core
-    #   requests-mock
-s3transfer==0.2.1
-    # via boto3
-sentry-sdk==0.13.4
-    # via -r requirements.in
-sigauth==4.1.1
-    # via directory-client-core
-six==1.12.0
-    # via
-    #   cryptography
-    #   django-countries
-    #   freezegun
-    #   jsonschema
-    #   packaging
-    #   pip-tools
-    #   pyopenssl
-    #   pyrsistent
-    #   pytest-xdist
-    #   python-dateutil
-    #   requests-mock
-    #   w3lib
-sorl-thumbnail==12.5.0
-    # via -r requirements.in
-soupsieve==1.9.3
-    # via beautifulsoup4
-sqlparse==0.3.0
-    # via django
-termcolor==1.1.0
-    # via pytest-sugar
-tzlocal==2.0.0
-    # via dateparser
-urllib3==1.24.3
-    # via
-    #   -r requirements.in
-    #   botocore
-    #   directory-validators
-    #   elastic-apm
-    #   requests
-    #   sentry-sdk
-w3lib==1.21.0
-    # via directory-client-core
-waitress==1.4.3
-    # via -r requirements.in
-wcwidth==0.1.7
-    # via pytest
-whitenoise==4.1.3
-    # via -r requirements.in
-zipp==0.6.0
-    # via importlib-metadata
+apipkg==1.5               # via execnet
+atomicwrites==1.3.0       # via pytest
+attrs==19.1.0             # via jsonschema, pytest
+beautifulsoup4==4.8.0     # via directory-components
+boto3==1.9.232            # via -r requirements.in
+botocore==1.12.232        # via boto3, s3transfer
+certifi==2019.9.11        # via elastic-apm, requests, sentry-sdk
+cffi==1.13.2              # via cryptography
+chardet==3.0.4            # via requests
+click==7.0                # via pip-tools
+codecov==2.1.9            # via -r requirements_test.in
+coverage==4.5.4           # via codecov, pytest-cov
+cryptography==3.3.2       # via pyopenssl, requests
+dateparser==0.7.0         # via -r requirements.in
+directory-api-client==20.0.0  # via -r requirements.in
+directory-client-core==6.1.0  # via directory-api-client, directory-cms-client, directory-forms-api-client, pir-client
+directory-cms-client==10.2.0  # via -r requirements.in
+directory-components==35.26.0  # via -r requirements.in
+directory-constants==20.11.0  # via -r requirements.in, directory-components
+directory-forms-api-client==5.1.0  # via -r requirements.in
+directory-healthcheck==2.0.0  # via -r requirements.in
+directory-validators==6.0.5  # via -r requirements.in
+django-countries==5.5     # via -r requirements.in
+django-environ==0.4.5     # via -r requirements.in
+django-formtools==2.1     # via -r requirements.in
+django-health-check==3.8.0  # via directory-healthcheck
+django-ipware==2.1.0      # via -r requirements.in
+django-recaptcha==2.0.5   # via -r requirements.in
+django-redis==4.10.0      # via -r requirements.in
+django-storages==1.7.2    # via -r requirements.in
+django==2.2.21            # via -r requirements.in, directory-api-client, directory-client-core, directory-components, directory-constants, directory-healthcheck, directory-validators, django-formtools, django-recaptcha, django-redis, django-storages, djangorestframework, sigauth
+djangorestframework==3.11.2  # via -r requirements.in, sigauth
+docutils==0.15.2          # via botocore
+elastic-apm==5.5.2        # via -r requirements.in
+entrypoints==0.3          # via flake8
+execnet==1.7.1            # via pytest-xdist
+flake8==3.7.8             # via -r requirements_test.in
+freezegun==0.3.12         # via -r requirements_test.in
+gevent==1.5a3             # via -r requirements.in
+greenlet==0.4.16          # via gevent
+gunicorn==20.0.4          # via -r requirements.in
+idna==2.8                 # via requests
+importlib-metadata==0.23  # via pluggy, pytest
+jmespath==0.9.4           # via boto3, botocore
+jsonschema==3.0.2         # via directory-components
+mccabe==0.6.1             # via flake8
+mohawk==0.3.4             # via sigauth
+monotonic==1.5            # via directory-client-core
+more-itertools==7.2.0     # via pytest, zipp
+olefile==0.44             # via directory-validators
+packaging==19.2           # via pytest, pytest-sugar
+pillow==8.1.2             # via directory-validators
+pip-tools==5.3.0          # via -r requirements_test.in
+pir-client==1.1.0         # via -r requirements.in
+pluggy==0.13.0            # via pytest
+psycogreen==1.0.2         # via -r requirements.in
+psycopg2==2.8.5           # via -r requirements.in
+py==1.10.0                # via -r requirements_test.in, pytest
+pycodestyle==2.5.0        # via flake8
+pycparser==2.19           # via cffi
+pyflakes==2.1.1           # via flake8
+pyopenssl==19.1.0         # via requests
+pyparsing==2.4.2          # via packaging
+pyrsistent==0.15.4        # via jsonschema
+pytest-cov==2.7.1         # via -r requirements_test.in
+pytest-django==3.5.1      # via -r requirements_test.in
+pytest-forked==1.0.2      # via pytest-xdist
+pytest-sugar==0.9.2       # via -r requirements_test.in
+pytest-xdist==1.29.0      # via -r requirements_test.in
+pytest==5.1.2             # via -r requirements_test.in, pytest-cov, pytest-django, pytest-forked, pytest-sugar, pytest-xdist
+python-dateutil==2.8.0    # via botocore, dateparser, freezegun
+pytz==2017.2              # via dateparser, directory-validators, django, tzlocal
+redis==3.3.8              # via django-redis
+regex==2019.8.19          # via dateparser
+requests-mock==1.7.0      # via -r requirements_test.in
+requests[security]==2.22.0  # via -r requirements.in, codecov, directory-api-client, directory-client-core, requests-mock
+s3transfer==0.2.1         # via boto3
+sentry-sdk==0.13.4        # via -r requirements.in
+sigauth==4.1.1            # via directory-client-core
+six==1.12.0               # via cryptography, django-countries, freezegun, jsonschema, packaging, pip-tools, pyopenssl, pyrsistent, pytest-xdist, python-dateutil, requests-mock, w3lib
+sorl-thumbnail==12.5.0    # via -r requirements.in
+soupsieve==1.9.3          # via beautifulsoup4
+sqlparse==0.3.0           # via django
+termcolor==1.1.0          # via pytest-sugar
+tzlocal==2.0.0            # via dateparser
+urllib3==1.24.3           # via -r requirements.in, botocore, directory-validators, elastic-apm, requests, sentry-sdk
+w3lib==1.21.0             # via directory-client-core
+waitress==1.4.3           # via -r requirements.in
+wcwidth==0.1.7            # via pytest
+whitenoise==4.1.3         # via -r requirements.in
+zipp==0.6.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
* Django to 2.2.21
* py to at least 1.10.0

NOTICKET: upgrade py dependency, too

To do (delete all that do not apply):

 - [X] Changelog entry added.
 - [X] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [X] (if updating requirements) Requirements have been compiled.
