### PR TITLE
NOTICKET: Bump django to 2.2.22 (security update)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ django-ipware==2.1.0
 django-recaptcha==2.0.5
 django-redis==4.10.0
 django-storages==1.7.2
-Django==2.2.21
+Django==2.2.22
 djangorestframework==3.11.2
 elastic-apm>=5.5.2,<6.0.0
 pir-client==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ django-ipware==2.1.0      # via -r requirements.in
 django-recaptcha==2.0.5   # via -r requirements.in
 django-redis==4.10.0      # via -r requirements.in
 django-storages==1.7.2    # via -r requirements.in
-django==2.2.21            # via -r requirements.in, directory-api-client, directory-client-core, directory-components, directory-constants, directory-healthcheck, directory-validators, django-formtools, django-recaptcha, django-redis, django-storages, djangorestframework, sigauth
+django==2.2.22            # via -r requirements.in, directory-api-client, directory-client-core, directory-components, directory-constants, directory-healthcheck, directory-validators, django-formtools, django-recaptcha, django-redis, django-storages, djangorestframework, sigauth
 djangorestframework==3.11.2  # via -r requirements.in, sigauth
 docutils==0.15.2          # via botocore
 elastic-apm==5.5.2        # via -r requirements.in

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -34,7 +34,7 @@ django-ipware==2.1.0      # via -r requirements.in
 django-recaptcha==2.0.5   # via -r requirements.in
 django-redis==4.10.0      # via -r requirements.in
 django-storages==1.7.2    # via -r requirements.in
-django==2.2.21            # via -r requirements.in, directory-api-client, directory-client-core, directory-components, directory-constants, directory-healthcheck, directory-validators, django-formtools, django-recaptcha, django-redis, django-storages, djangorestframework, sigauth
+django==2.2.22            # via -r requirements.in, directory-api-client, directory-client-core, directory-components, directory-constants, directory-healthcheck, directory-validators, django-formtools, django-recaptcha, django-redis, django-storages, djangorestframework, sigauth
 djangorestframework==3.11.2  # via -r requirements.in, sigauth
 docutils==0.15.2          # via botocore
 elastic-apm==5.5.2        # via -r requirements.in


### PR DESCRIPTION

 - [X] Existing changelog entry is still appropriate
 - [X] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [X] (if updating requirements) Requirements have been compiled.
