### PR TITLE
Remove MS Defender Safe Links from client requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Pre-release
+- GP2-3282 - Middleware to remove PII from MS Safe Links in request path
 - GP2-3226 - Added InvestmentAtlas Landing page
 
 ### Implemented enhancements

--- a/conf/settings.py
+++ b/conf/settings.py
@@ -81,6 +81,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.common.CommonMiddleware',
     'core.middleware.GoogleCampaignMiddleware',
+    'core.middleware.MicrosoftDefenderSafeLinksMiddleware',
     'directory_components.middleware.NoCacheMiddlware',
     'directory_components.middleware.CheckGATags'
 ]

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -34,7 +34,7 @@ class GoogleCampaignMiddleware(MiddlewareMixin):
 class MicrosoftDefenderSafeLinksMiddleware(MiddlewareMixin):
     """PII in the form of email addresses is injected into links by a
     MS 365 email client as values to a 'data' parameter.
-    
+
     These 'safe links' don't appear to have a consistent pattern, the small sample
     data available looks like:
 

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,4 +1,5 @@
 from django.utils.deprecation import MiddlewareMixin
+import re
 
 
 class GoogleCampaignMiddleware(MiddlewareMixin):
@@ -28,3 +29,35 @@ class GoogleCampaignMiddleware(MiddlewareMixin):
         # store utm codes on the request object,
         # so they're available in templates
         request.utm = request.session['utm']
+
+
+class MicrosoftDefenderSafeLinksMiddleware(MiddlewareMixin):
+    """PII in the form of email addresses is injected into links by a
+    MS 365 email client as values to a 'data' parameter.
+    
+    These 'safe links' don't appear to have a consistent pattern, the small sample
+    data available looks like:
+
+    - /international/content/opportunities/<https://eur02..safelinks.protection.outlook.com/ \
+        ?url=[url]&data=[PII!]&sdata=[sdata]&reserved=0
+
+    - /international/trade/<https://eur02.safelinks.protection.outlook.com/ \
+        ?url=[url]&data=[PII!]&sdata=[sdata]&reserved=0
+
+    - /international/?amp;data=[PII!]&amp;sdata=[sdata]&amp;reserved=0&lang=en-gb
+
+    - /international/?lang=zh-hans<https://eur02.safelinks.protection.outlook.com/ \
+        ?url=[url]?lang=zh-hans&data=[PII!]&sdata=[sdata]&reserved=0
+
+    - /international/invest/<https://eur02.safelinks.protection.outlook.com/ \
+        ?url=[url]&data=[PII!]&sdata=[sdata]&reserved=0>.
+
+    This middleware removes the 'data' parameter and its value from a request path
+    that is added by Microsoft 365 Defender, thus PII does not get captured in Google Analytics."""
+
+    SAFE_LINKS_REGEX = r'[&|amp;]data=.*?\|[\w\.-]+@[\w\.-]+(?:\.[\w]+)+\|.*?(?=&)'
+
+    def process_request(self, request):
+        clean_query_string = re.sub(self.SAFE_LINKS_REGEX, '', request.META['QUERY_STRING'])
+
+        request.META['QUERY_STRING'] = clean_query_string

--- a/core/tests/test_middleware.py
+++ b/core/tests/test_middleware.py
@@ -52,7 +52,11 @@ def test_microsoft_defender_safe_links_middleware_trims_pii(client):
             + '&data=04|01|someone@example.com|52e1fcc870ff4ef072|8fa217ec|0|0|63748103|Unknown|TWFpbGZsb3d8eyJWI=|1000'
             + '&sdata=6pfgjx6NF3ZWP2TQQjdI1XuB5xx/HGm2sgaokntWjvk='
             + '&reserved=0',
-            'lang=zh-hans<https://eur02.safelinks.protection.outlook.com/?url=https://www.great.gov.uk/international/?lang=zh-hans&sdata=6pfgjx6NF3ZWP2TQQjdI1XuB5xx/HGm2sgaokntWjvk=&reserved=0',
+            'lang=zh-hans<https://eur02.safelinks.protection.outlook.com/'
+            + '?url=https://www.great.gov.uk/international/'
+            + '?lang=zh-hans'
+            + '&sdata=6pfgjx6NF3ZWP2TQQjdI1XuB5xx/HGm2sgaokntWjvk='
+            + '&reserved=0',
         ),
         (
             '/international/invest/'
@@ -61,7 +65,9 @@ def test_microsoft_defender_safe_links_middleware_trims_pii(client):
             + '&data=04|01|someone@example.com|f852c1f4a2814bf1d0|8fa217ec|0|0|63749854|Unknown|TWFpbGZsb3d8eyJWI=|1000'
             + '&sdata=LISO/lFPrI++ZLbztFWfWhyQuTTdJDrgX5OYX+dR4Fo='
             + '&reserved=0>.',
-            'url=https://www.great.gov.uk/international/invest/&sdata=LISO/lFPrI++ZLbztFWfWhyQuTTdJDrgX5OYX+dR4Fo=&reserved=0>.',
+            'url=https://www.great.gov.uk/international/invest/'
+            + '&sdata=LISO/lFPrI++ZLbztFWfWhyQuTTdJDrgX5OYX+dR4Fo='
+            + '&reserved=0>.',
         ),
         (
             '/international/trade/<https://eur02.safelinks.protection.outlook.com/'
@@ -69,7 +75,9 @@ def test_microsoft_defender_safe_links_middleware_trims_pii(client):
             + '&data=04|01|someone@example.com|717be13dae814422c8|30a43325|1|0|63749997|Unknown|TWFpbGZsb3d8eyJWI=|1000'
             + '&sdata=VwFyrskaWXwX9WY/GHHNh9Tqc6471gLjT+jfwkB2vag='
             + '&reserved=0',
-            'url=https://www.great.gov.uk/international/trade/&sdata=VwFyrskaWXwX9WY/GHHNh9Tqc6471gLjT+jfwkB2vag=&reserved=0',
+            'url=https://www.great.gov.uk/international/trade/'
+            + '&sdata=VwFyrskaWXwX9WY/GHHNh9Tqc6471gLjT+jfwkB2vag='
+            + '&reserved=0',
         ),
         (
             '/international/content/opportunities/<https://eur02..safelinks.protection.outlook.com/'
@@ -77,7 +85,9 @@ def test_microsoft_defender_safe_links_middleware_trims_pii(client):
             + '&data=04|01|someone@example.com|cd323113628a419d7b|8fa217ec|0|0|63748721|Unknown|TWFpbGZsb3d8eyJWI=|1000'
             + '&sdata=RMR1sDN435f61sERPSfe8vtgTwluVrzePnSN8YehsnE='
             + '&reserved=0',
-            'url=https://www.great.gov.uk/international/content/opportunities/&sdata=RMR1sDN435f61sERPSfe8vtgTwluVrzePnSN8YehsnE=&reserved=0',
+            'url=https://www.great.gov.uk/international/content/opportunities/'
+            + '&sdata=RMR1sDN435f61sERPSfe8vtgTwluVrzePnSN8YehsnE='
+            + '&reserved=0',
         ),
     ]
 
@@ -86,6 +96,7 @@ def test_microsoft_defender_safe_links_middleware_trims_pii(client):
         request = response.wsgi_request
 
         assert request.META['QUERY_STRING'] == expected_query_string
+
 
 def test_microsoft_defender_safe_links_middleware_respects_legitimate_data_param(client):
     path = '/international/content/opportunities/?data=my_data'


### PR DESCRIPTION
Personal Identifiable Information (PII) in the form of email addresses is injected into links by Outlook as values to a `data` parameter.

These 'safe links' don't appear to have a consistent pattern, a small sample data available looks like:

 - `/international/content/opportunities/<https://eur02..safelinks.protection.outlook.com/?url=[url]&data=[PII]&sdata=[sdata]&reserved=0`
 - `/international/trade/<https://eur02.safelinks.protection.outlook.com/?url=[url]&data=[PII]&sdata=[sdata]&reserved=0`
 - `/international/?amp;data=[PII]&amp;sdata=[sdata]&amp;reserved=0&lang=en-gb`
 - `/international/?lang=zh-hans<https://eur02.safelinks.protection.outlook.com/?url=[url]?lang=zh-hans&data=[PII]&sdata=[sdata]&reserved=0`
 - `/international/invest/<https://eur02.safelinks.protection.outlook.com/?url=[url]&data=[PII]&sdata=[sdata]&reserved=0>.`

This PR adds middleware to remove the `data` parameter and its value from a request path that is added by Microsoft 365 Defender, thus PII does not get captured in Google Analytics.

To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.

