### PR TITLE
GP2-3375: Remove sectors list from Find-A-Supplier search page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+- GP2-3375 - Remove auto-included sectors from Find a Supplier page + update menu for 'Buy from the UK'
 - GP2-3392 - Use specific hero and intro images for InvestmentOpportunityPage, following CMS changes
 - NO_TICKET - fixed nav item urls
 - GP2-3223 - Update codebase for new sector modelling in CMS

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -38,6 +38,8 @@ urlpatterns = [
         QuerystringRedirectView.as_view(url='/international/investment-support-directory/')
     ),
     url(
+        # Note that some of these URLS from find-a-supplier are superceded by later
+        # entries in the URLConf
         r'^international/trade/',
         include(
             'find_a_supplier.urls',
@@ -255,6 +257,7 @@ urlpatterns += [
         r'^trade/(?P<path>industries\/.*)/$',
         find_a_supplier.views.LegacySupplierURLRedirectView.as_view(),
     ),
+    # These override at least one route from the find-a-supplier namespace, included far above
     url(
         r'^international/trade/incoming/$',  # Homepage
         QuerystringRedirectView.as_view(pattern_name='trade-home'),

--- a/core/header_config/nav_tree.py
+++ b/core/header_config/nav_tree.py
@@ -73,7 +73,11 @@ ATLAS_HEADER_TREE = [
     ),
     NavNode(
             tier_one_item=tier_one_nav_items.BUY_FROM_THE_UK,
-            tier_two_items=[]
+            tier_two_items=[
+                tier_two_nav_items.HOW_WE_HELP_BUY,
+                tier_two_nav_items.FIND_A_SUPPLIER,
+                tier_two_nav_items.CONTACT_US_TRADE,
+            ]
     ),
     NavNode(
         tier_one_item=tier_one_nav_items.CONTACT,

--- a/find_a_supplier/templates/find_a_supplier/landing_page.html
+++ b/find_a_supplier/templates/find_a_supplier/landing_page.html
@@ -74,6 +74,7 @@
     </div>
 </section>
 
+{% comment "This does work with the new Sector setup in Atlas, but has been disabled for now" %}    
 <section id="industries-section" class="padding-bottom-60-m padding-bottom-30 background-stone-30">
     <div class="container">
         <div class="heading-large">
@@ -89,6 +90,7 @@
         <a class="button" href="{% url 'industries' %}">{{ page.industries_list_call_to_action_text }}</a>
     </div>
 </section>
+{% endcomment %}
 
 <section id="services-section" class="padding-bottom-60-m padding-bottom-30">
     <div class="container">

--- a/find_a_supplier/tests/test_templates.py
+++ b/find_a_supplier/tests/test_templates.py
@@ -4,6 +4,10 @@ from django.utils import translation
 from django.template.loader import render_to_string
 
 
+@pytest.mark.skip(
+    'Skipped while the sector/industries panel is hidden '
+    'in find_a_supplier/templates/find_a_supplier/landing_page.html'
+)
 @pytest.mark.parametrize('lang,exp_industries', [
     ('en-gb', 3),
     ('de', 2),


### PR DESCRIPTION
This changeset removes the Sector/Industry panel from the Find A Supplier page, as requested by the content team.

It also adds in a sub-nav (black strip) for the sibling pages in the Buy From the UK section we're retaining. 

![Screenshot 2021-09-10 at 16-53-33 How we help you buy from the UK - great gov uk international](https://user-images.githubusercontent.com/101457/132883144-cd166b6c-99cc-4059-a282-8e0c8f9a6b3b.png)



 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
