### PR TITLE
NOTICKET: Remove now-redundant back link from contact triage page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+- NOTICKET - Remove now-redundant back link from contact triage page
 - GP2-3407 - Rename HPO contact page as FDI and move into Atlas
 - NOTICKET - For related pages, rendering hero image if exists
 - GP2-3408 - Regions name changes to UK Nations and Regions

--- a/core/templates/core/contact_international_triage.html
+++ b/core/templates/core/contact_international_triage.html
@@ -35,9 +35,11 @@
                 </fieldset>
             </div>
         </div>
+        {% comment "Disabled because we no longer treat great.gov.uk/contact/ as the root of the contact triage flow" %}
         <div class="margin-top-30">
             <a href="{{ domestic_contact_home }}" type="submit" >{% trans "Back" %}</a>
         </div>
+        {% endcomment %}
     </div>
 </section>
 


### PR DESCRIPTION


 - [X] Changelog entry added.
