### PR TITLE
GP2-3407: Make FDI form path match that of page in CMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+- GP2-3407 - Make FDI form path match that of page in CMS
 - NOTICKET - Fix FE securities vulnerabilities 
 - NOTICKET - Remove now-redundant back link from contact triage page
 - GP2-3407 - Rename HPO contact page as FDI and move into Atlas

--- a/conf/tests/test_redirects.py
+++ b/conf/tests/test_redirects.py
@@ -31,19 +31,19 @@ redirects = [
     ),
     (
         '/international/content/invest/high-potential-opportunities/contact/',
-        '/international/content/investment/foreign-direct-investment-contact-form/'
+        '/international/content/investment/foreign-direct-investment-contact/'
     ),
     (
         '/international/content/invest/high-potential-opportunities/contact/success/',
-        '/international/content/investment/foreign-direct-investment-contact-form/success/'
+        '/international/content/investment/foreign-direct-investment-contact/success/'
     ),
     (
         '/international/content/expand/high-potential-opportunities/contact/',
-        '/international/content/investment/foreign-direct-investment-contact-form/'
+        '/international/content/investment/foreign-direct-investment-contact/'
     ),
     (
         '/international/content/expand/high-potential-opportunities/contact/success/',
-        '/international/content/investment/foreign-direct-investment-contact-form/success/',
+        '/international/content/investment/foreign-direct-investment-contact/success/',
     ),
 ]
 

--- a/conf/urls.py
+++ b/conf/urls.py
@@ -369,13 +369,13 @@ urlpatterns += [
         name='atlas-opportunities'
     ),
     url(
-        r'^international/content/investment/foreign-direct-investment-contact-form/$',
+        r'^international/content/investment/foreign-direct-investment-contact/$',
         investment_atlas.views.ForeignDirectInvestmentOpportunityFormView.as_view(),
         {'path': 'investment/foreign-direct-investment-contact'},
         name='fdi-opportunity-request-form'
     ),
     url(
-        r'^international/content/investment/foreign-direct-investment-contact-form/success/$',
+        r'^international/content/investment/foreign-direct-investment-contact/success/$',
         investment_atlas.views.ForeignDirectInvestmentOpportunitySuccessView.as_view(),
         {'path': 'investment/foreign-direct-investment-contact/success'},
         name='fdi-opportunity-request-form-success'

--- a/core/constants.py
+++ b/core/constants.py
@@ -54,8 +54,6 @@ TEMPLATE_MAPPING = {
     'InternationalInvestmentSubSectorPage': 'investment_atlas/sector.html',
     'InvestmentGeneralContentPage': 'investment_atlas/general_content_page.html',
     'WhyInvestInTheUKPage': 'investment_atlas/why_invest_in_the_uk_page.html',
-    'ForeignDirectInvestmentFormPage': 'investment_atlas/fdi_opportunities_form.html',
-    'ForeignDirectInvestmentFormSuccessPage': 'investment_atlas/fdi_opportunities_form_success.html',
 }
 
 FEATURE_FLAGGED_URLS_MAPPING = {


### PR DESCRIPTION
 Make FDI form path match that of page in CMS so that when you "view live" from the CMS you end up on the actual page, not a broken one.

Also delete unneeded serializer mapping to the fdi templates -- they are directly mapped in urls.py before the magic catchall route is triggered

To do (delete all that do not apply):

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
