### PR TITLE
 NOTICKET - Add support for case studies to Region detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Pre-release
 
 ### Implemented enhancements
+- NOTICKET - Add support for case studies to Region detail page
 - GP2-3407 - Make FDI form path match that of page in CMS
 - NOTICKET - Fix FE securities vulnerabilities 
 - NOTICKET - Remove now-redundant back link from contact triage page

--- a/investment_atlas/templates/investment_atlas/region.html
+++ b/investment_atlas/templates/investment_atlas/region.html
@@ -93,10 +93,42 @@
                     </div>
                 </div>
 
-
             </div>
         </div>
     </section>
+
+    {% if page.case_study_title and page.case_study_text %}
+    <section>
+        <div class="atlas-container atlas-p-t-l atlas-p-b-m">
+            <h2 class="atlas-h--l">{{ page.case_study_title }}</h2>
+
+            <div class="atlas-grid atlas-grid--masonry atlas-p-t-s">
+                {% if page.case_study_image %}
+                    <div class="atlas-grid__column atlas-grid__column--right atlas-grid__column--6-12-m atlas-m-b-m">
+                        <img class="atlas-image"
+                             src="{{ page.case_study_image.url }}"
+                             alt="{{ page.case_study_image.alt }}">
+                    </div>
+                {% endif %}
+                <div class="atlas-grid__column atlas-grid__column--left atlas-grid__column--{% if page.case_study_image %}6{% else %}8{% endif %}-12-m atlas-m-b-m">
+                    <div class="atlas-cms-text atlas-p-b-m">
+                        {{ page.case_study_text|safe }}
+                    </div>
+
+                    {% if page.case_study_cta_link and page.case_study_cta_text %}
+                    <a href="{{ page.case_study_cta_link }}" class="atlas-button atlas-m-b-m">
+                        {{ page.case_study_cta_text }}
+                        <span class="atlas-button__icon">
+                            {% include 'investment_atlas/includes/svg/icon-arrow.svg' %}
+                        </span>
+                    </a>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </section>
+    {% endif %}
+
 
     {% include 'investment_atlas/includes/speak_to_us.html' %}
 {% endblock %}


### PR DESCRIPTION
This follows a pattern set for Success Stories on other pages and also the Find A Supplier CTA markup

 - [X] Changelog entry added.
