### PR TITLE
Fix error when blank related sector selected

### DIFF
--- a/investment_atlas/helpers.py
+++ b/investment_atlas/helpers.py
@@ -1,10 +1,14 @@
 def get_sectors_label(page):
     sectors_label = ''
 
-    if 'related_sectors' in page and len(page['related_sectors']) > 0:
-        sectors_label = page['related_sectors'][0]['related_sector']['title']
+    if 'related_sectors' in page:
+        related_sectors = [sector for sector in page['related_sectors'] if sector['related_sector']]
+        if related_sectors:
+            sectors_label = related_sectors[0]['related_sector']['title']
 
-        if 'sub_sectors' in page and len(page['sub_sectors']) > 0:
-            sectors_label += ' ({})'.format(', '.join(page['sub_sectors']))
+            if 'sub_sectors' in page:
+                sub_sectors = [sub_sector for sub_sector in page['sub_sectors'] if sub_sector]
+                if sub_sectors:
+                    sectors_label += ' ({})'.format(', '.join(sub_sectors))
 
     return sectors_label

--- a/investment_atlas/tests/test_helpers.py
+++ b/investment_atlas/tests/test_helpers.py
@@ -13,6 +13,22 @@ def test_get_sectors_label():
     assert helpers.get_sectors_label(page) == 'Housing (Green housing, Urban, Renting)'
 
 
+def test_get_sectors_label_undefined_sectors():
+    page = {}
+
+    assert helpers.get_sectors_label(page) == ''
+
+
+def test_get_sectors_label_undefined_sub_sectors():
+    page = {  # NOQA
+        'related_sectors': [
+            {'related_sector': {'title': 'Housing'}}
+        ]
+    }
+
+    assert helpers.get_sectors_label(page) == 'Housing'
+
+
 def test_get_sectors_label_no_sector():
     page = {  # NOQA
         'related_sectors': [],
@@ -29,6 +45,27 @@ def test_get_sectors_label_no_subsectors():
             {'related_sector': {'title': 'Aerospace'}}
         ],
         'sub_sectors': []
+    }
+
+    assert helpers.get_sectors_label(page) == 'Housing'
+
+
+def test_get_sectors_label_blank_sector():
+    page = {  # NOQA
+        'related_sectors': [
+            {'related_sector': []}
+        ]
+    }
+
+    assert helpers.get_sectors_label(page) == ''
+
+
+def test_get_sectors_label_blank_sub_sector():
+    page = {  # NOQA
+        'related_sectors': [
+            {'related_sector': {'title': 'Housing'}},
+        ],
+        'sub_sectors': ['']
     }
 
     assert helpers.get_sectors_label(page) == 'Housing'


### PR DESCRIPTION
Prevents a template error when a blank sector is selected. Related sector label logic is now fully resilient.

To do (delete all that do not apply):

 - [ ] Change has a jira ticket that has the correct status.
 - [ ] Changelog entry added.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.
 - [ ] (if adding CSS) CSS have been compiled.
 - [ ] (if adding HTML) Change is accessible to the standards we subscribe to.
 - [ ] (if changing content) Locale files have been updated and translated strings have been added if available.
 - [ ] (if adding env vars) Added any new environment variable to vault.
 - [ ] (if adding feature flags) Cleaned up old flags
 - [ ] (if changing the UI) Add a printscreen to the PR
