### PR TITLE
Add Bing Webmaster Tools meta tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - NOTICKET - Remove unused CSS
 - GP2-3775 - Multi sector FE display
 - GP2-3872 - Filters updates
+- GP2-3895 - Add Bing Webmaster Tools site verification
 
 ### Fixed bugs
 

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -42,11 +42,14 @@
     <link rel="stylesheet" href="{% static 'core/styles/main.css' %}">
 {% endblock %}
 
-{% block head_other %}{% endblock %}
+{% block head_other %}
+    <meta name="msvalidate.01" content="76D322F181AE9F91C43419E5CD511BBC"/>
+{% endblock %}
 
 {% block head_sharing_metadata %}
     {% if request %}
         <meta property="og:image" content="
+
 
                 {% block meta_sharing_thumbnail %}{% static_absolute 'directory_components/images/opengraph-image.png' %}{% endblock %}">
         <meta property="og:url" content="{{ request.build_absolute_uri }}"/>


### PR DESCRIPTION
Adds the Bing Webmaster Tools site verification as meta tag to all pages under /international/.

To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.
 - [ ] (if adding CSS) CSS have been compiled.
 - [x] (if adding HTML) Change is accessible to the standards we subscribe to.
 - [ ] (if changing content) Locale files have been updated and translated strings have been added if available.
 - [ ] (if adding env vars) Added any new environment variable to vault.
 - [ ] (if adding feature flags) Cleaned up old flags
 - [ ] (if changing the UI) Add a printscreen to the PR
