### PR TITLE
Ensure `head_other` block calls ancestor

### DIFF
--- a/contact/templates/contact/base.html
+++ b/contact/templates/contact/base.html
@@ -2,9 +2,10 @@
 {% load static from staticfiles %}
 
 {% block head_other %}
-  {% for url, language_code in localised_urls %}
-    <link rel="alternate" href="{{ url }}" hreflang="{{ language_code }}">
-  {% endfor %}
+    {{ block.super }}
+    {% for url, language_code in localised_urls %}
+        <link rel="alternate" href="{{ url }}" hreflang="{{ language_code }}">
+    {% endfor %}
 {% endblock %}
 
 {% block css_layout_class %}invest-contact-page{% endblock %}

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -48,10 +48,11 @@
 
 {% block head_sharing_metadata %}
     {% if request %}
-        <meta property="og:image" content="
-
-
-                {% block meta_sharing_thumbnail %}{% static_absolute 'directory_components/images/opengraph-image.png' %}{% endblock %}">
+        <meta property="og:image" content="{% spaceless %}
+            {% block meta_sharing_thumbnail %}
+                {% static_absolute 'directory_components/images/opengraph-image.png' %}
+            {% endblock %}
+        {% endspaceless %}">
         <meta property="og:url" content="{{ request.build_absolute_uri }}"/>
     {% endif %}
 {% endblock %}

--- a/core/templates/core/base_cms.html
+++ b/core/templates/core/base_cms.html
@@ -1,12 +1,14 @@
 {% extends 'core/base.html' %}
 {% load static %}
 
-{% block head_title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %} - {{ international_home_link.label }}{% endblock %}
+{% block head_title %}{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %} -
+    {{ international_home_link.label }}{% endblock %}
 
 {% block head_other %}
-  {% for language_code, url in page.meta.localised_urls %}
-    <link rel="alternate" href="{{ url }}" hreflang="{{ language_code }}">
-  {% endfor %}
+    {{ block.super }}
+    {% for language_code, url in page.meta.localised_urls %}
+        <link rel="alternate" href="{{ url }}" hreflang="{{ language_code }}">
+    {% endfor %}
 {% endblock %}
 
 {% block head_sharing_metadata %}
@@ -15,9 +17,9 @@
 {% endblock %}
 
 {% block meta_sharing_thumbnail %}
-  {% if page.hero_thumbnail %}
-    {{ page.hero_thumbnail }}
-  {% else %}
-    {{ block.super }}
-  {% endif %}
+    {% if page.hero_thumbnail %}
+        {{ page.hero_thumbnail }}
+    {% else %}
+        {{ block.super }}
+    {% endif %}
 {% endblock %}

--- a/second_qualification/templates/second_qualification/base.html
+++ b/second_qualification/templates/second_qualification/base.html
@@ -2,7 +2,8 @@
 {% load static from staticfiles %}
 
 {% block head_other %}
-  {% for url, language_code in localised_urls %}
-    <link rel="alternate" href="{{ url }}" hreflang="{{ language_code }}">
-  {% endfor %}
+    {{ block.super }}
+    {% for url, language_code in localised_urls %}
+        <link rel="alternate" href="{{ url }}" hreflang="{{ language_code }}">
+    {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Bing `<meta>` tag was not showing on most pages as the `head_other` template block was being overridden. This fix ensures the base block is called first.

To do (delete all that do not apply):

 - [ ] Change has a jira ticket that has the correct status.
 - [ ] Changelog entry added.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.
 - [ ] (if adding CSS) CSS have been compiled.
 - [ ] (if adding HTML) Change is accessible to the standards we subscribe to.
 - [ ] (if changing content) Locale files have been updated and translated strings have been added if available.
 - [ ] (if adding env vars) Added any new environment variable to vault.
 - [ ] (if adding feature flags) Cleaned up old flags
 - [ ] (if changing the UI) Add a printscreen to the PR
