### PR TITLE
GLS-220/221 link to filtered results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ### Implemented enhancements
 
+- GLS-221 - link to opportunities filtered by sector
+
 ### Fixed bugs
+
+- GLS-220 - fix regional filter not applying to results
 
 ## [3.5.4](https://github.com/uktrade/great-international-ui/releases/tag/3.5.4)
 

--- a/investment_atlas/templates/investment_atlas/opportunity_listing_page.html
+++ b/investment_atlas/templates/investment_atlas/opportunity_listing_page.html
@@ -13,6 +13,10 @@
 {% endblock %}
 
 {% block content %}
+    {% url 'atlas-opportunities' as base_url %}
+    {% update_query_params investment_type='' sector='' sub_sector='' as clear_type_query %}
+    {% update_query_params investment_type='' region='' sector='' sub_sector='' as clear_all_query %}
+
     {% with results_count=pagination.object_list|length %}
         <form id="opportunities-search-form" action="{{ paginator_url }}"
               class="atlas-bg--grey-lighter{% if form.view.value == 'map' and results_count > 0 %} atlas-search--as-map{% endif %}">
@@ -53,7 +57,8 @@
                                         <ul>
                                             {% for choice in form.investment_type %}
                                                 <li class="atlas-p-t-s">
-                                                    <a href="?{% update_query_params investment_type=choice.choice_label view=form.view.value %}"
+                                                    {% update_query_params investment_type=choice.choice_label as type_query %}
+                                                    <a href="{{ base_url }}{{ type_query }}"
                                                        class="atlas-search__investment-type atlas-link--invert">{{ choice.choice_label }}</a>
                                                 </li>
                                             {% endfor %}
@@ -67,7 +72,7 @@
                                     <fieldset aria-labelledby="selected_investment_type">
                                         <div class="atlas-search-type">
                                             <a class="atlas-search-type__clear atlas-body--m"
-                                               href="{% url 'atlas-opportunities' %}?view={{ form.view.value }}">
+                                               href="{{ base_url }}{{ clear_type_query }}">
                                                 <span class="atlas-icon">
                                                     {% include 'investment_atlas/includes/svg/icon-arrow.svg' %}
                                                 </span>
@@ -102,7 +107,7 @@
                                     {% endif %}
 
                                     <p class="atlas-m-0 atlas-p-v-s">
-                                        <a class="atlas-link" href="{% url 'atlas-opportunities' %}">
+                                        <a class="atlas-link" href="{{ base_url }}{{ clear_all_query }}">
                                             {% trans 'Clear all filters' %}
                                         </a>
                                     </p>
@@ -135,7 +140,9 @@
                                 {{ num_of_opportunities }}
                                 {% if selected_investment_type %}
                                     <a class="atlas-link" aria-label="Change investment type"
-                                       href="{% url 'atlas-opportunities' %}">{{ selected_investment_type|lower }}</a>
+                                       href="{{ base_url }}{{ clear_type_query }}">
+                                        {{ selected_investment_type|lower }}
+                                    </a>
                                 {% endif %}
                                 opportunit{{ num_of_opportunities|pluralize:"y,ies" }} found
                             </p>
@@ -180,7 +187,7 @@
                                     <h3 class="atlas-h--s atlas-m-b-s">No results</h3>
                                     <p class="atlas-body--m">{% trans 'We couldn’t find any opportunities - please try some different filters.' %}</p>
                                     <p class="atlas-body--m atlas-m-0">
-                                        <a class="atlas-link" href="{% url 'atlas-opportunities' %}">
+                                        <a class="atlas-link" href="{{ base_url }}{{ clear_all_query }}">
                                             {% trans 'Clear all filters' %}
                                         </a>
                                     </p>
@@ -190,26 +197,30 @@
                             {% if pagination.paginator.num_pages > 1 %}
                                 <div class="atlas-pagination">
                                     {% if pagination.has_previous %}
-                                        <a href="?{% update_query_params page=pagination.previous_page_number %}"
-                                           class="atlas-button atlas-pagination__previous">
-                                            <span class="atlas-button__icon atlas-button__icon--first">
-                                               {% include 'investment_atlas/includes/svg/icon-arrow.svg' %}
-                                            </span>
-                                            Previous
-                                        </a>
+                                        {% with prev_page=pagination.previous_page_number %}
+                                            <a href="{{ base_url }}{% update_query_params page=prev_page %}"
+                                               class="atlas-button atlas-pagination__previous">
+                                                <span class="atlas-button__icon atlas-button__icon--first">
+                                                   {% include 'investment_atlas/includes/svg/icon-arrow.svg' %}
+                                                </span>
+                                                Previous
+                                            </a>
+                                        {% endwith %}
                                     {% endif %}
 
                                     <p class="atlas-pagination__number">Page {{ pagination.number }}
                                         of {{ pagination.paginator.num_pages }}</p>
 
                                     {% if pagination.has_next %}
-                                        <a href="?{% update_query_params page=pagination.next_page_number %}"
-                                           class="atlas-button atlas-pagination__next">
-                                            Next
-                                            <span class="atlas-button__icon">
-                                               {% include 'investment_atlas/includes/svg/icon-arrow.svg' %}
-                                            </span>
-                                        </a>
+                                        {% with next_page=pagination.next_page_number %}
+                                            <a href="{{ base_url }}{% update_query_params page=next_page %}"
+                                               class="atlas-button atlas-pagination__next">
+                                                Next
+                                                <span class="atlas-button__icon">
+                                                   {% include 'investment_atlas/includes/svg/icon-arrow.svg' %}
+                                                </span>
+                                            </a>
+                                        {% endwith %}
                                     {% endif %}
                                 </div>
                             {% endif %}

--- a/investment_atlas/templates/investment_atlas/region.html
+++ b/investment_atlas/templates/investment_atlas/region.html
@@ -41,11 +41,11 @@
 
                 {% include 'investment_atlas/includes/related_opportunities.html' with opportunities=page.related_opportunities %}
 
-                <p class="atlas-m-t-l atlas-m-b-s"><a
-                        href="/international/investment/opportunities/?region={{ page.title|urlencode }}"
-                        class="atlas-link">View all
-                    investment opportunities
-                    in {{ page.title }}</a></p>
+                <p class="atlas-m-t-l atlas-m-b-s">
+                    <a href="{% url 'atlas-opportunities' %}?region={{ page.title|urlencode }}" class="atlas-link">
+                        View all investment opportunities in {{ page.title }}
+                    </a>
+                </p>
             </div>
         </section>
     {% endif %}

--- a/investment_atlas/templates/investment_atlas/sector.html
+++ b/investment_atlas/templates/investment_atlas/sector.html
@@ -39,8 +39,10 @@
 
                     {% include 'investment_atlas/includes/related_opportunities.html' with opportunities=page.related_opportunities %}
 
-                    <p class="atlas-m-t-l atlas-m-b-s"><a href="/international/investment/opportunities/"
-                                                          class="atlas-link">View all investment opportunities</a>
+                    <p class="atlas-m-t-l atlas-m-b-s">
+                        <a href="{% url 'atlas-opportunities' %}?sector={{ page.title|urlencode }}" class="atlas-link">
+                            View all investment opportunities in this sector
+                        </a>
                     </p>
                 </div>
             </section>

--- a/investment_atlas/templatetags/atlas_tags.py
+++ b/investment_atlas/templatetags/atlas_tags.py
@@ -10,7 +10,10 @@ register = template.Library()
 def update_query_params(context, **kwargs):
     query = context['request'].GET.copy()
     for key, value in kwargs.items():
-        query.__setitem__(key, value)
+        if value:
+            query.__setitem__(key, value)
+        else:
+            query.pop(key, None)
     return query.urlencode()
 
 

--- a/investment_atlas/templatetags/atlas_tags.py
+++ b/investment_atlas/templatetags/atlas_tags.py
@@ -14,7 +14,8 @@ def update_query_params(context, **kwargs):
             query.__setitem__(key, value)
         else:
             query.pop(key, None)
-    return query.urlencode()
+
+    return f'?{query.urlencode()}' if query else ''
 
 
 @register.inclusion_tag('investment_atlas/includes/collapsible_text.html')

--- a/investment_atlas/tests/test_templatetags.py
+++ b/investment_atlas/tests/test_templatetags.py
@@ -6,18 +6,18 @@ from django.test import RequestFactory
 
 
 @pytest.mark.parametrize('query_string, arguments, expected', (
-        ('foo=bar&baz=1', 'page=3', 'foo=bar&amp;baz=1&amp;page=3'),
-        ('foo=bar&baz=1&page=2', 'page=3', 'foo=bar&amp;baz=1&amp;page=3'),
-        ('page=1', 'page=3', 'page=3'),
-        ('', 'page=3', 'page=3'),
-        ('foo=bar', 'foo=""', ''),
-        ('foo=bar&page=2', 'foo=""', 'page=2'),
-        ('foo=bar&baz=1&page=2', 'foo=""', 'baz=1&amp;page=2'),
-        ('baz=two', 'foo=""', 'baz=two'),
+        ('?foo=bar&baz=1', 'page=3', '?foo=bar&amp;baz=1&amp;page=3'),
+        ('?foo=bar&baz=1&page=2', 'page=3', '?foo=bar&amp;baz=1&amp;page=3'),
+        ('?page=1', 'page=3', '?page=3'),
+        ('', 'page=3', '?page=3'),
+        ('?foo=bar', 'foo=""', ''),
+        ('?foo=bar&page=2', 'foo=""', '?page=2'),
+        ('?foo=bar&baz=1&page=2', 'foo=""', '?baz=1&amp;page=2'),
+        ('?baz=two', 'foo=""', '?baz=two'),
 ))
 def test_update_query(query_string, arguments, expected):
     request_factory = RequestFactory()
-    request = request_factory.get('/page-url?{}'.format(query_string))
+    request = request_factory.get('/page-url{}'.format(query_string))
     template = Template(
         '{{% load update_query_params from atlas_tags %}}{{% update_query_params {} %}}'.format(arguments))
     context = Context({'request': request})

--- a/investment_atlas/tests/test_templatetags.py
+++ b/investment_atlas/tests/test_templatetags.py
@@ -27,13 +27,17 @@ def test_update_query(query_string, arguments, expected):
 
 
 @pytest.mark.parametrize('id, input, has_button, visible, collapsed', (
-        ('id1', '<p>some text</p>', False, '<p>some text</p>', ''),  # Does not split if no <hr>
-        ('id2', '<p>some text</p><hr><p>more text</p>', True, '<p>some text</p>', '<p>more text</p>'),  # Splits if <hr>
-        ('id3', '<p>some text</p><hr>', False, '<p>some text</p>', ''),  # Does not split if no content after <hr>
+        # Does not split if no <hr>
+        ('id1', '<p>some text</p>', False, '<p>some text</p>', ''),
+        # Splits if <hr>
+        ('id2', '<p>some text</p><hr><p>more text</p>', True, '<p>some text</p>', '<p>more text</p>'),
+        # Does not split if no content after <hr>
+        ('id3', '<p>some text</p><hr>', False, '<p>some text</p>', ''),
+        # Only splits first <hr>
         ('id4', '<p>some text</p><hr><p>more text</p><hr><p>even more text</p>', True, '<p>some text</p>',
-        '<p>more text</p><hr/><p>even more text</p>'),  # Only splits first <hr>
-        ('id5', '<p>some text</p><hr/><p>more text</p>', True, '<p>some text</p>', '<p>more text</p>'),
+            '<p>more text</p><hr/><p>even more text</p>'),
         # Splits if <hr/>
+        ('id5', '<p>some text</p><hr/><p>more text</p>', True, '<p>some text</p>', '<p>more text</p>'),
 ))
 def test_collapsible_cms_text(id, input, has_button, visible, collapsed):
     template = Template(
@@ -70,12 +74,12 @@ def test_cms_url(settings):
 @pytest.mark.parametrize('page_url, filter_name, chosen_filters, shows_and, remove_urls', (
         # One filter
         ("/page-url?foo=One", 'foo', ['One'], False, ["/page-url"]),
-            # Two filters
+        # Two filters
         ("/page-url?foo=One&foo=Two", 'foo', ['One', 'Two'], True, ["/page-url?foo=Two", "/page-url?foo=One"]),
-            # Three filters
+        # Three filters
         ("/?foo=One&foo=Two&foo=Three", 'foo', ['One', 'Two', 'Three'], True,
-        ["/?foo=Two&amp;foo=Three", "/?foo=One&amp;foo=Three", "/?foo=One&amp;foo=Two"]),
-            # test other parameters are retained
+            ["/?foo=Two&amp;foo=Three", "/?foo=One&amp;foo=Three", "/?foo=One&amp;foo=Two"]),
+        # test other parameters are retained
         ("/?foo=One&bar=baz", 'foo', ['One'], False, ["/?bar=baz"])
 
 ))

--- a/investment_atlas/tests/test_views.py
+++ b/investment_atlas/tests/test_views.py
@@ -214,25 +214,6 @@ def test_investment_type_filter_for_opportunity_search():
     assert response.context_data['pagination'].object_list[1]['title'] == 'Some Opp 2'
 
 
-def test_atlas_opportunities_ignores_other_filters_if_no_investment_type_selected():
-    page = create_opportunities_page()
-
-    response = create_opportunities_response(
-        page,
-        '/international/investment/opportunities/?sector=Automotive&region=South+of+England&sub_sector=Chemicals'
-    )
-
-    assert len(response.context_data['pagination'].object_list) == 10
-    assert response.context_data['pagination'].object_list[0]['title'] == 'Some Opp 1'
-    assert response.context_data['form']['region'].initial == []
-    assert response.context_data['form']['sector'].initial == []
-    assert response.context_data['form']['sub_sector'].initial == []
-
-    assert response.context_data['form'].fields['region'].choices == []
-    assert response.context_data['form'].fields['sector'].choices == []
-    assert response.context_data['form'].fields['sub_sector'].choices == []
-
-
 def test_atlas_opportunities_shows_sector_with_count_and_region_filters_for_foreign_direct_investment_search():
     page = create_opportunities_page()
 
@@ -318,7 +299,7 @@ def test_atlas_opportunities_applies_region_filter():
     response = create_opportunities_response(
         page,
         '/international/investment/opportunities/' +
-        '?investment_type=Foreign+direct+investment&region=Midlands'
+        '?region=Midlands'
     )
 
     assert len(response.context_data['pagination'].object_list) == 1
@@ -331,7 +312,7 @@ def test_atlas_opportunities_applies_sector_filter():
     response = create_opportunities_response(
         page,
         '/international/investment/opportunities/' +
-        '?investment_type=Foreign+direct+investment&sector=Automotive'
+        '?sector=Automotive'
     )
 
     assert len(response.context_data['pagination'].object_list) == 1

--- a/investment_atlas/views.py
+++ b/investment_atlas/views.py
@@ -206,23 +206,23 @@ class InvestmentOpportunitySearchView(CountryDisplayMixin, InternationalView):
 
         filtered_opportunities = [opp for opp in self.opportunities]
 
+        if self.sector.sectors:
+            filtered_opportunities = core_helpers.filter_opportunities(
+                filtered_opportunities,
+                self.sector
+            )
+
+        if self.region.regions:
+            filtered_opportunities = core_helpers.filter_opportunities(
+                filtered_opportunities,
+                self.region
+            )
+
         if self.investment_type.investment_type:
             filtered_opportunities = core_helpers.filter_opportunities(
                 filtered_opportunities,
                 self.investment_type
             )
-
-            if self.sector.sectors:
-                filtered_opportunities = core_helpers.filter_opportunities(
-                    filtered_opportunities,
-                    self.sector
-                )
-
-            if self.region.regions:
-                filtered_opportunities = core_helpers.filter_opportunities(
-                    filtered_opportunities,
-                    self.region
-                )
 
             if self.sub_sector.sub_sectors:
                 filtered_opportunities = core_helpers.filter_opportunities(
@@ -270,9 +270,11 @@ class InvestmentOpportunitySearchView(CountryDisplayMixin, InternationalView):
     @property
     def filters_chosen(self):
         filters = []
+
+        for sector in self.sector.sectors:
+            filters.append(sector)
+
         if self.investment_type.investment_type:
-            for sector in self.sector.sectors:
-                filters.append(sector)
             for sub_sector in self.sub_sector.sub_sectors:
                 filters.append(sub_sector)
             # NOTE: disabled filters
@@ -286,9 +288,9 @@ class InvestmentOpportunitySearchView(CountryDisplayMixin, InternationalView):
     @property
     def regions_chosen(self):
         regions = []
-        if self.investment_type.investment_type:
-            for region in self.region.regions:
-                regions.append(region)
+
+        for region in self.region.regions:
+            regions.append(region)
 
         return regions
 


### PR DESCRIPTION
Adds the ability to show investment opportunities results filtered by region or sector even when investment type has not been selected. Links to investment opportunities on region and sector pages now specify the relevant region or sector.

To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [ ] (if updating requirements) Requirements have been compiled.
 - [ ] (if adding CSS) CSS have been compiled.
 - [x] (if adding HTML) Change is accessible to the standards we subscribe to.
 - [ ] (if changing content) Locale files have been updated and translated strings have been added if available.
 - [ ] (if adding env vars) Added any new environment variable to vault.
 - [ ] (if adding feature flags) Cleaned up old flags
 - [ ] (if changing the UI) Add a printscreen to the PR
