### PR TITLE
Show Shetland Islands on regions map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Hotfix
 
 ### Fixed bugs
+- GLS-305 - Show Shetlands on UK regions map
 
 ### Implemented enhancements
 

--- a/investment_atlas/templates/investment_atlas/includes/svg/regions-map.svg.html
+++ b/investment_atlas/templates/investment_atlas/includes/svg/regions-map.svg.html
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 523 834" preserveAspectRatio="xMidYMid meet"
+<svg viewBox="0 -82 523 921" preserveAspectRatio="xMidYMid meet"
      xmlns="http://www.w3.org/2000/svg"
      xmlns:xlink="http://www.w3.org/1999/xlink">
     <g transform="translate(-160.038)" fill="none" fill-rule="evenodd">


### PR DESCRIPTION
This PR updates the viewbox of the UK regions SVG map so that the Shetland islands are no longer hidden.

**Screenshot before**
![Screenshot 2022-09-05 at 11 06 36](https://user-images.githubusercontent.com/22460823/188424335-3cb9c1bc-4398-458a-b9a5-32632a8b60f7.png)

**Screenshot after**
![Screenshot 2022-09-05 at 11 05 55](https://user-images.githubusercontent.com/22460823/188424197-daff20d7-f1c1-463f-90bb-54eb4e82456f.png)

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if changing the UI) Add a printscreen to the PR
