### PR TITLE
Upgrade elastic-apm to version 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed bugs
 - GLS-305 - Show Shetlands on UK regions map
+- GLS-388 - Upgrade elastic-apm to version 6
 
 ### Implemented enhancements
 - GLS-388 - Upgrade for Django 3.2

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ django-redis==4.10.0
 django-storages==1.7.2
 Django==3.2.15
 djangorestframework==3.11.2
-elastic-apm>=5.5.2,<6.0.0
+elastic-apm==6.1.*
 pir-client==1.1.0
 requests[security]==2.25.1
 sentry-sdk==0.13.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ cffi==1.15.1
     # via cryptography
 chardet==4.0.0
     # via requests
-cryptography==38.0.0
+cryptography==38.0.1
     # via
     #   -r requirements.in
     #   pyopenssl
@@ -92,7 +92,7 @@ djangorestframework==3.11.2
     # via
     #   -r requirements.in
     #   sigauth
-elastic-apm==5.10.1
+elastic-apm==6.1.3
     # via -r requirements.in
 gevent==21.8.0
     # via -r requirements.in

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -39,7 +39,7 @@ coverage==6.4.4
     # via
     #   codecov
     #   pytest-cov
-cryptography==38.0.0
+cryptography==38.0.1
     # via
     #   -r requirements.in
     #   pyopenssl
@@ -104,7 +104,7 @@ djangorestframework==3.11.2
     # via
     #   -r requirements.in
     #   sigauth
-elastic-apm==5.10.1
+elastic-apm==6.1.3
     # via -r requirements.in
 execnet==1.9.0
     # via pytest-xdist


### PR DESCRIPTION
This PR upgrades the `elastic-apm` package to version 6, as version 5 is incompatible with python3.9 ([docs here](https://www.elastic.co/guide/en/apm/agent/python/5.x/supported-technologies.html)). 

To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if updating requirements) Requirements have been compiled.
