### PR TITLE
Upgrade whitenoise to 6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - GLS-435 - Remove emergency banner
 
 ### Fixed bugs
+- GLS-436 - Upgrade Whitenoise to 6.2.0
 
 ### Implemented enhancements
 

--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ sentry-sdk==0.13.4
 sorl-thumbnail==12.9.0
 urllib3>=1.24.2,<2.0.0
 waitress==2.1.2
-whitenoise==4.1.3
+whitenoise==6.2.0
 gunicorn==20.1.0
 psycogreen==1.0.2
 psycopg2==2.8.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ botocore==1.20.112
     # via
     #   boto3
     #   s3transfer
-certifi==2022.6.15.1
+certifi==2022.9.14
     # via
     #   elastic-apm
     #   requests
@@ -189,7 +189,7 @@ w3lib==2.0.1
     # via directory-client-core
 waitress==2.1.2
     # via -r requirements.in
-whitenoise==4.1.3
+whitenoise==6.2.0
     # via -r requirements.in
 wrapt==1.14.1
     # via deprecated

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -22,7 +22,7 @@ botocore==1.20.112
     #   s3transfer
 build==0.8.0
     # via pip-tools
-certifi==2022.6.15.1
+certifi==2022.9.14
     # via
     #   elastic-apm
     #   requests
@@ -241,7 +241,7 @@ soupsieve==2.3.2.post1
     # via beautifulsoup4
 sqlparse==0.4.2
     # via django
-termcolor==1.1.0
+termcolor==2.0.1
     # via pytest-sugar
 tomli==2.0.1
     # via
@@ -266,7 +266,7 @@ waitress==2.1.2
     # via -r requirements.in
 wheel==0.37.1
     # via pip-tools
-whitenoise==4.1.3
+whitenoise==6.2.0
     # via -r requirements.in
 wrapt==1.14.1
     # via deprecated


### PR DESCRIPTION
This PR upgrades the `Whitenoise` package in order to fix an issue in which javascript and css files are not decompressed when accessing the site in Safari.

The issue comes from using Django version 3.x with Whitenoise < 5 ([issue details here](https://code.djangoproject.com/ticket/31082)).

**Testing locally**
The issue only appears in the live environments, but I have deployed this branch to dev & staging to test and it has been successful.

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if updating requirements) Requirements have been compiled.
