### PR TITLE
Upgrade to django 3.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Hotfix
 
 ### Fixed bugs
+* Upgrade to django 3.2.16
 
 ### Implemented enhancements
 

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ directory-cms-client==12.0.0
 directory-components==38.0.0
 directory-forms-api-client==7.1.0
 directory-healthcheck==3.0.0
-directory-validators==9.2.0
+directory-validators==9.2.1
 django-countries==5.5
 django-environ==0.4.5
 django-formtools==2.1
@@ -13,7 +13,7 @@ django-ipware==2.1.0
 django-recaptcha==3.0.0
 django-redis==5.2.*
 django-storages==1.13.1
-Django==3.2.15
+Django==3.2.16
 djangorestframework==3.11.2
 elastic-apm==6.1.*
 pir-client==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ botocore==1.20.112
     # via
     #   boto3
     #   s3transfer
-certifi==2022.9.14
+certifi==2022.9.24
     # via
     #   elastic-apm
     #   requests
@@ -48,15 +48,15 @@ directory-cms-client==12.0.0
     # via -r requirements.in
 directory-components==38.0.0
     # via -r requirements.in
-directory-constants==22.0.0
+directory-constants==22.0.1
     # via directory-components
 directory-forms-api-client==7.1.0
     # via -r requirements.in
 directory-healthcheck==3.0.0
     # via -r requirements.in
-directory-validators==9.2.0
+directory-validators==9.2.1
     # via -r requirements.in
-django==3.2.15
+django==3.2.16
     # via
     #   -r requirements.in
     #   directory-api-client
@@ -128,7 +128,7 @@ psycopg2==2.8.5
     # via -r requirements.in
 pycparser==2.21
     # via cffi
-pyopenssl==22.0.0
+pyopenssl==22.1.0
     # via requests
 pyparsing==3.0.9
     # via packaging
@@ -171,9 +171,9 @@ sorl-thumbnail==12.9.0
     # via -r requirements.in
 soupsieve==2.3.2.post1
     # via beautifulsoup4
-sqlparse==0.4.2
+sqlparse==0.4.3
     # via django
-tzdata==2022.2
+tzdata==2022.5
     # via pytz-deprecation-shim
 tzlocal==4.2
     # via dateparser
@@ -195,7 +195,7 @@ wrapt==1.14.1
     # via deprecated
 zope-event==4.5.0
     # via gevent
-zope-interface==5.4.0
+zope-interface==5.5.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -20,9 +20,9 @@ botocore==1.20.112
     # via
     #   boto3
     #   s3transfer
-build==0.8.0
+build==0.9.0
     # via pip-tools
-certifi==2022.9.14
+certifi==2022.9.24
     # via
     #   elastic-apm
     #   requests
@@ -35,7 +35,7 @@ click==8.1.3
     # via pip-tools
 codecov==2.1.9
     # via -r requirements_test.in
-coverage==6.4.4
+coverage==6.5.0
     # via
     #   codecov
     #   pytest-cov
@@ -60,15 +60,15 @@ directory-cms-client==12.0.0
     # via -r requirements.in
 directory-components==38.0.0
     # via -r requirements.in
-directory-constants==22.0.0
+directory-constants==22.0.1
     # via directory-components
 directory-forms-api-client==7.1.0
     # via -r requirements.in
 directory-healthcheck==3.0.0
     # via -r requirements.in
-directory-validators==9.2.0
+directory-validators==9.2.1
     # via -r requirements.in
-django==3.2.15
+django==3.2.16
     # via
     #   -r requirements.in
     #   directory-api-client
@@ -106,6 +106,8 @@ djangorestframework==3.11.2
     #   sigauth
 elastic-apm==6.1.3
     # via -r requirements.in
+exceptiongroup==1.0.0
+    # via pytest
 execnet==1.9.0
     # via pytest-xdist
 flake8==5.0.4
@@ -150,7 +152,7 @@ pillow==9.2.0
     # via
     #   -r requirements_test.in
     #   directory-validators
-pip-tools==6.8.0
+pip-tools==6.9.0
     # via -r requirements_test.in
 pir-client==1.1.0
     # via -r requirements.in
@@ -163,7 +165,6 @@ psycopg2==2.8.5
 py==1.11.0
     # via
     #   -r requirements_test.in
-    #   pytest
     #   pytest-forked
 pycodestyle==2.9.1
     # via flake8
@@ -171,13 +172,13 @@ pycparser==2.21
     # via cffi
 pyflakes==2.5.0
     # via flake8
-pyopenssl==22.0.0
+pyopenssl==22.1.0
     # via requests
 pyparsing==3.0.9
     # via packaging
 pyrsistent==0.18.1
     # via jsonschema
-pytest==7.1.3
+pytest==7.2.0
     # via
     #   -r requirements_test.in
     #   pytest-cov
@@ -239,7 +240,7 @@ sorl-thumbnail==12.9.0
     # via -r requirements.in
 soupsieve==2.3.2.post1
     # via beautifulsoup4
-sqlparse==0.4.2
+sqlparse==0.4.3
     # via django
 termcolor==2.0.1
     # via pytest-sugar
@@ -248,7 +249,7 @@ tomli==2.0.1
     #   build
     #   pep517
     #   pytest
-tzdata==2022.2
+tzdata==2022.5
     # via pytz-deprecation-shim
 tzlocal==4.2
     # via dateparser
@@ -272,7 +273,7 @@ wrapt==1.14.1
     # via deprecated
 zope-event==4.5.0
     # via gevent
-zope-interface==5.4.0
+zope-interface==5.5.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
This PR upgrades django to version `3.2.16` and directory-validators to `9.2.1` which supports this newer version of django.

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
 - [x] (if updating requirements) Requirements have been compiled.
