### PR TITLE
Upgrade changelog with versions 4.1.1-4.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 ### Implemented enhancements
 
+## [4.1.2](https://github.com/uktrade/great-international-ui/releases/tag/4.1.2)
+### Implemented enhancements
+- KLS-327 - Upgrade json5 from 2.2.21 to 2.2.3
+
+## [4.1.1](https://github.com/uktrade/great-international-ui/releases/tag/4.1.1)
+### Implemented enhancements
+
+- Bump certifi from 2022.9.24 to 2022.12.7
+
 ## [4.1.0](https://github.com/uktrade/great-international-ui/releases/tag/4.1.0)
 
 ### Implemented enhancements


### PR DESCRIPTION
This PR upgrades the changelog to include the last 2 releases.