### PR TITLE
Update whitenoise to 6.4.0 and its staticfiles storage settings

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -204,7 +204,7 @@ STATIC_HOST = env.str('STATIC_HOST', '')
 STATIC_URL = STATIC_HOST + '/static/'
 STATICFILES_STORAGE = env.str(
     'STATICFILES_STORAGE',
-    'whitenoise.storage.CompressedManifestStaticFilesStorage'
+    'whitenoise.storage.CompressedStaticFilesStorage'
 )
 
 # Logging for development

--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ sentry-sdk==1.14.0
 sorl-thumbnail==12.9.0
 urllib3>=1.24.2,<2.0.0
 waitress==2.1.2
-whitenoise==6.2.0
+whitenoise==6.4.0
 gunicorn==20.1.0
 psycogreen==1.0.2
 psycopg2==2.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -165,7 +165,7 @@ soupsieve==2.4.1
     # via beautifulsoup4
 sqlparse==0.4.4
     # via django
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via asgiref
 tzlocal==5.0.1
     # via dateparser
@@ -181,7 +181,7 @@ w3lib==1.22.0
     # via directory-client-core
 waitress==2.1.2
     # via -r requirements.in
-whitenoise==6.2.0
+whitenoise==6.4.0
     # via -r requirements.in
 zope-event==4.6
     # via gevent

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -250,7 +250,7 @@ tomli==2.0.1
     #   coverage
     #   pyproject-hooks
     #   pytest
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via asgiref
 tzlocal==5.0.1
     # via dateparser
@@ -268,7 +268,7 @@ waitress==2.1.2
     # via -r requirements.in
 wheel==0.40.0
     # via pip-tools
-whitenoise==6.2.0
+whitenoise==6.4.0
     # via -r requirements.in
 zope-event==4.6
     # via gevent


### PR DESCRIPTION
Updates whiteness package to clear sentry error

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
