### PR TITLE
Upgraded requests to 2.31.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,11 +13,12 @@ django-ipware==2.1.0
 django-recaptcha==3.0.0
 django-redis==5.2.*
 django-storages==1.13.1
+django-oauth-toolkit==2.2.0
 Django==4.1.9
 djangorestframework==3.11.2
 elastic-apm==6.1.*
 pir-client==1.2.1
-requests[security]==2.25.1
+requests[security]==2.31.0
 sentry-sdk==1.14.0
 sorl-thumbnail==12.9.0
 urllib3>=1.24.2,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-asgiref==3.7.1
+asgiref==3.7.2
     # via django
 async-timeout==4.0.2
     # via redis
@@ -25,15 +25,16 @@ certifi==2023.5.7
     #   sentry-sdk
 cffi==1.15.1
     # via cryptography
-chardet==4.0.0
+charset-normalizer==3.1.0
     # via requests
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r requirements.in
-    #   pyopenssl
-    #   requests
+    #   jwcrypto
 dateparser==0.7.0
     # via -r requirements.in
+deprecated==1.2.14
+    # via jwcrypto
 directory-api-client==26.3.0
     # via -r requirements.in
 directory-client-core==7.2.2
@@ -65,6 +66,7 @@ django==4.1.9
     #   directory-validators
     #   django-formtools
     #   django-health-check
+    #   django-oauth-toolkit
     #   django-recaptcha
     #   django-redis
     #   django-storages
@@ -79,6 +81,8 @@ django-formtools==2.1
 django-health-check==3.17.0
     # via directory-healthcheck
 django-ipware==2.1.0
+    # via -r requirements.in
+django-oauth-toolkit==2.2.0
     # via -r requirements.in
 django-recaptcha==3.0.0
     # via -r requirements.in
@@ -100,7 +104,7 @@ greenlet==2.0.2
     #   gevent
 gunicorn==20.1.0
     # via -r requirements.in
-idna==2.10
+idna==3.4
     # via requests
 jmespath==0.10.0
     # via
@@ -108,10 +112,14 @@ jmespath==0.10.0
     #   botocore
 jsonschema==3.2.0
     # via directory-components
+jwcrypto==1.5.0
+    # via django-oauth-toolkit
 mohawk==1.1.0
     # via sigauth
 monotonic==1.6
     # via directory-client-core
+oauthlib==3.2.2
+    # via django-oauth-toolkit
 olefile==0.46
     # via directory-validators
 pillow==9.5.0
@@ -124,8 +132,6 @@ psycopg2==2.9.5
     # via -r requirements.in
 pycparser==2.21
     # via cffi
-pyopenssl==23.1.1
-    # via requests
 pyrsistent==0.19.3
     # via jsonschema
 python-dateutil==2.8.2
@@ -142,11 +148,12 @@ regex==2022.1.18
     # via
     #   -r requirements.in
     #   dateparser
-requests[security]==2.25.1
+requests[security]==2.31.0
     # via
     #   -r requirements.in
     #   directory-api-client
     #   directory-client-core
+    #   django-oauth-toolkit
 s3transfer==0.4.2
     # via boto3
 sentry-sdk==1.14.0
@@ -165,7 +172,7 @@ soupsieve==2.4.1
     # via beautifulsoup4
 sqlparse==0.4.4
     # via django
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via asgiref
 tzlocal==5.0.1
     # via dateparser
@@ -183,6 +190,8 @@ waitress==2.1.2
     # via -r requirements.in
 whitenoise==6.4.0
     # via -r requirements.in
+wrapt==1.15.0
+    # via deprecated
 zope-event==4.6
     # via gevent
 zope-interface==6.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements_test.in
 #
-asgiref==3.7.1
+asgiref==3.7.2
     # via django
 async-timeout==4.0.2
     # via redis
@@ -27,21 +27,22 @@ certifi==2023.5.7
     #   sentry-sdk
 cffi==1.15.1
     # via cryptography
-chardet==4.0.0
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via pip-tools
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via
     #   pytest-codecov
     #   pytest-cov
-cryptography==40.0.2
+cryptography==41.0.1
     # via
     #   -r requirements.in
-    #   pyopenssl
-    #   requests
+    #   jwcrypto
 dateparser==0.7.0
     # via -r requirements.in
+deprecated==1.2.14
+    # via jwcrypto
 directory-api-client==26.3.0
     # via -r requirements.in
 directory-client-core==7.2.2
@@ -73,6 +74,7 @@ django==4.1.9
     #   directory-validators
     #   django-formtools
     #   django-health-check
+    #   django-oauth-toolkit
     #   django-recaptcha
     #   django-redis
     #   django-storages
@@ -87,6 +89,8 @@ django-formtools==2.1
 django-health-check==3.17.0
     # via directory-healthcheck
 django-ipware==2.1.0
+    # via -r requirements.in
+django-oauth-toolkit==2.2.0
     # via -r requirements.in
 django-recaptcha==3.0.0
     # via -r requirements.in
@@ -120,7 +124,7 @@ greenlet==2.0.2
     #   gevent
 gunicorn==20.1.0
     # via -r requirements.in
-idna==2.10
+idna==3.4
     # via requests
 iniconfig==2.0.0
     # via pytest
@@ -130,12 +134,16 @@ jmespath==0.10.0
     #   botocore
 jsonschema==3.2.0
     # via directory-components
+jwcrypto==1.5.0
+    # via django-oauth-toolkit
 mccabe==0.7.0
     # via flake8
 mohawk==1.1.0
     # via sigauth
 monotonic==1.6
     # via directory-client-core
+oauthlib==3.2.2
+    # via django-oauth-toolkit
 olefile==0.46
     # via directory-validators
 packaging==23.1
@@ -167,8 +175,6 @@ pycparser==2.21
     # via cffi
 pyflakes==3.0.1
     # via flake8
-pyopenssl==23.1.1
-    # via requests
 pyproject-hooks==1.0.0
     # via build
 pyrsistent==0.19.3
@@ -211,11 +217,12 @@ regex==2022.1.18
     # via
     #   -r requirements.in
     #   dateparser
-requests[security]==2.25.1
+requests[security]==2.31.0
     # via
     #   -r requirements.in
     #   directory-api-client
     #   directory-client-core
+    #   django-oauth-toolkit
     #   pytest-codecov
     #   requests-mock
 requests-mock==1.10.0
@@ -250,7 +257,7 @@ tomli==2.0.1
     #   coverage
     #   pyproject-hooks
     #   pytest
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via asgiref
 tzlocal==5.0.1
     # via dateparser
@@ -270,6 +277,8 @@ wheel==0.40.0
     # via pip-tools
 whitenoise==6.4.0
     # via -r requirements.in
+wrapt==1.15.0
+    # via deprecated
 zope-event==4.6
     # via gevent
 zope-interface==6.0


### PR DESCRIPTION
Upgrades requests to 2.31.0 and adds an additional dependancy to django-oauth-toolkit to fix compatibility with Django 4.1.9

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-712
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Housekeeping

- [x] Upgraded any vulnerable dependencies.
- [x] I have updated security dependencies
- [x] Python requirements have been re-compiled.

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
