### PR TITLE
fixed flake8 to 6.1.0

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,32 @@
+FROM python:3.9.2
+
+### 1. Set environment variables
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV DOCKERIZE_VERSION v0.6.1
+
+### 2. Setup GDAL
+RUN apt-get update &&\
+    apt-get -y install gettext ;\
+    apt-get -y  install httpie; \
+    apt-get install -y binutils libproj-dev gdal-bin python3-gdal
+
+
+### 3. Add dockerize to allow waiting for the DB to load.
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+### 4. Create working directory
+RUN mkdir /app
+COPY . /app/
+WORKDIR /app
+
+### 5. Install packages
+RUN set -e; \
+    /usr/local/bin/python -m pip install --upgrade pip ;\
+    python -m pip install pip-tools ;\
+    python -m pip install -r /app/requirements_test.txt ;
+
+### 6. Expose port
+EXPOSE 8012

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.7.2
     # via django
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via redis
 attrs==23.1.0
     # via jsonschema
@@ -27,7 +27,7 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.2.0
     # via requests
-cryptography==41.0.2
+cryptography==41.0.3
     # via
     #   -r requirements.in
     #   jwcrypto
@@ -142,7 +142,7 @@ pytz==2023.3
     # via
     #   dateparser
     #   directory-validators
-redis==4.6.0
+redis==5.0.0
     # via django-redis
 regex==2022.1.18
     # via

--- a/requirements_test.in
+++ b/requirements_test.in
@@ -5,7 +5,7 @@ pytest>=4.4.0<5.0.0
 pytest-django>=3.5.1<4.0.0
 pytest-sugar
 pytest-xdist==1.29.0
-flake8
+flake8==6.1.0
 requests_mock
 freezegun
 pytest-cov

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.7.2
     # via django
-async-timeout==4.0.2
+async-timeout==4.0.3
     # via redis
 attrs==23.1.0
     # via jsonschema
@@ -29,13 +29,13 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.2.0
     # via requests
-click==8.1.6
+click==8.1.7
     # via pip-tools
-coverage[toml]==7.2.7
+coverage[toml]==7.3.0
     # via
     #   pytest-codecov
     #   pytest-cov
-cryptography==41.0.2
+cryptography==41.0.3
     # via
     #   -r requirements.in
     #   jwcrypto
@@ -104,11 +104,11 @@ djangorestframework==3.11.2
     #   sigauth
 elastic-apm==6.1.3
     # via -r requirements.in
-exceptiongroup==1.1.2
+exceptiongroup==1.1.3
     # via pytest
 execnet==2.0.2
     # via pytest-xdist
-flake8==6.0.0
+flake8==6.1.0
     # via -r requirements_test.in
 freezegun==1.2.2
     # via -r requirements_test.in
@@ -155,7 +155,7 @@ pillow==10.0.0
     # via
     #   -r requirements_test.in
     #   directory-validators
-pip-tools==7.1.0
+pip-tools==7.3.0
     # via -r requirements_test.in
 pir-client==1.2.1
     # via -r requirements.in
@@ -169,11 +169,11 @@ py==1.11.0
     # via
     #   -r requirements_test.in
     #   pytest-forked
-pycodestyle==2.10.0
+pycodestyle==2.11.0
     # via flake8
 pycparser==2.21
     # via cffi
-pyflakes==3.0.1
+pyflakes==3.1.0
     # via flake8
 pyproject-hooks==1.0.0
     # via build
@@ -211,7 +211,7 @@ pytz==2023.3
     # via
     #   dateparser
     #   directory-validators
-redis==4.6.0
+redis==5.0.0
     # via django-redis
 regex==2022.1.18
     # via
@@ -275,7 +275,7 @@ w3lib==1.22.0
     # via directory-client-core
 waitress==2.1.2
     # via -r requirements.in
-wheel==0.41.0
+wheel==0.41.2
     # via pip-tools
 whitenoise==6.4.0
     # via -r requirements.in


### PR DESCRIPTION
This PR is to fix the flake8 package to 6.1.0 to avoid new checks / standards on the Python code. This will avoid a situation where we see deployment failures occurring; 

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/KLS-990
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers.
