### PR TITLE
KLS-1596: Remove other option from contact form

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -241,6 +241,5 @@ class InternationalRoutingForm(forms.Form):
             (constants.CAPITAL_INVEST_CONTACT_URL, _('Investing capital in the UK')),
             (constants.EXPORTING_TO_UK_CONTACT_URL, _('Exporting to the UK')),
             (constants.BUYING_CONTACT_URL, _('Buying from the UK')),
-            (constants.OTHER_CONTACT_URL, _('Other')),
         )
         return ((value, label) for value, label in all_choices if self.choice_is_enabled(value))

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -635,7 +635,7 @@ def test_about_uk_breadcrumbs_article_page_feature_off(
 @pytest.mark.parametrize(
     'choice_contact_url',
     [constants.INVEST_CONTACT_URL, constants.CAPITAL_INVEST_CONTACT_URL, constants.EXPORTING_TO_UK_CONTACT_URL,
-     constants.BUYING_CONTACT_URL, constants.OTHER_CONTACT_URL]
+     constants.BUYING_CONTACT_URL]
 )
 def test_international_contact_triage_redirects(
         choice_contact_url, client, feature_flags


### PR DESCRIPTION
Removes 'Other' option from contact form

### Workflow

- [X] Ticket exists in Jira https://uktrade.atlassian.net/browse/TICKET_ID_HERE
- [X] Jira ticket has the correct status.
- [X] A clear/description pull request messaged added.


### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
