### PR TITLE
Bug fix issue with hero video source type attribute value

### DIFF
--- a/investment_atlas/templates/investment_atlas/includes/hero_image.html
+++ b/investment_atlas/templates/investment_atlas/includes/hero_image.html
@@ -10,7 +10,7 @@
                     {% endfor%}
                 {% elif page.hero_video.url and page.hero_video.file_extension %}
                     <source src="{{ page.hero_video.url }}"
-                            type="{{ page.hero_video.file_extension }}">
+                            type="video/{{ page.hero_video.file_extension }}">
                 {% endif %}
             </video>
         {% else %}


### PR DESCRIPTION
Issue observed with some hero videos not displaying/playing

A typo fix in a previous release seems to have corrected the typo but brought about an issue where the video source type value should be prefixed with `video/`. The typo meant that previously no source type was rendered so its probable that the browser did the gap fill. 

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
