### PR TITLE
Pointing contact us footer link to great-cms international contact form instead of EYB

### DIFF
--- a/core/templates/atlas/components/footer.html
+++ b/core/templates/atlas/components/footer.html
@@ -26,7 +26,7 @@
                            href="https://www.great.gov.uk/accessibility-statement/" target="_blank">{% trans 'Accessibility' %}</a>
                     </li>
                     <li>
-                        <a id="footer-contact" href="/international/expand-your-business-in-the-uk/contact">
+                        <a id="footer-contact" href="/international/contact/">
                             {% trans 'Contact us' %}</a>
                     </li>
                     <li>


### PR DESCRIPTION
Pointing contact us footer link to great-cms international contact form instead of EYB

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/IOO-1198
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Reviewing help

- [x] Explains how to test locally, including how to set up appropriate data

### Housekeeping

N/A

### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
