### PR TITLE
noopener noreferrer added to external link to stop the target page ac…

### DIFF
--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -107,7 +107,7 @@ number of extra CSS styles that were once sensible defaults:
     <section dir="ltr" class="error-reporting">
         <div class="container">
             <a id="error-reporting-section-contact-us" href="{{ services_urls.feedback }}"
-               target="_blank">{% trans 'Is there anything wrong on this page?' %}</a>
+               target="_blank" rel="noopener noreferrer">{% trans 'Is there anything wrong on this page?' %}</a>
         </div>
     </section>
 {% endblock %}


### PR DESCRIPTION
…cessing the DOM

CodeQl : HTML links that open in a new tab or window allow the target page to access the DOM of the origin page using window.opener unless link type noopener or noreferrer is specified. This is a potential security risk.

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GREATUK-556
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.

### Merging

- [x] This PR can be merged by reviewers.
