### PR TITLE
GRTLV-53 - Add cookies link to footer and change privacy label

### DIFF
--- a/core/templates/atlas/components/footer.html
+++ b/core/templates/atlas/components/footer.html
@@ -18,7 +18,14 @@
                            title="{% trans 'Opens in a new window' %}"
                            rel="noopener noreferrer"
                            target="_blank"
-                           href="{{ header_footer_urls.privacy_and_cookies }}">{% trans 'Privacy and cookies' %}</a>
+                           href="{{ header_footer_urls.privacy_and_cookies }}">{% trans 'Privacy' %}</a>
+                    </li>
+                    <li>
+                        <a id="footer-cookies"
+                           title="{% trans 'Opens in a new window' %}"
+                           rel="noopener noreferrer"
+                           target="_blank"
+                           href="/cookies/">{% trans 'Cookies' %}</a>
                     </li>
                     <li>
                         <a id="footer-terms-and-conditions"


### PR DESCRIPTION
To fit with recent changes on domestic, this change is to update the footer links to have a link to the cookies settings page and change the "privacy and cookies" link label to "privacy".

### Workflow

- [x] Ticket exists in Jira https://uktrade.atlassian.net/browse/GRTLV-53
- [x] Jira ticket has the correct status.
- [x] A clear/description pull request messaged added.
- [ ] 
### Merging

- [x] This PR can be merged by reviewers. (If unticked, please leave for the author to merge)
